### PR TITLE
workspace id and cluster type

### DIFF
--- a/notebooks/Utils/workspace_bootstrap.py
+++ b/notebooks/Utils/workspace_bootstrap.py
@@ -96,6 +96,7 @@ except Exception:
 # COMMAND ----------
 
 bootstrap('clusters', cluster_client.get_cluster_list, alive=False)
+#this returns job, api and ui clusters
 
 # COMMAND ----------
 


### PR DESCRIPTION
(a) workspace Id get from outer loop rather than trying to get it from currently running workspace (b) Make all checks for cluster type UI or API. Job cluster checks are done via Job definitions.