### PR TITLE
Fix issue with error trapping for api calls

### DIFF
--- a/notebooks/Setup/5. import_dashboard_template.py
+++ b/notebooks/Setup/5. import_dashboard_template.py
@@ -52,7 +52,7 @@ response = requests.get(
           json=None,
           timeout=60 
         )
-if '\"error_code\":\"403\"' not in response.text:
+if response.status_code == 200:
     resources = json.loads(response.text)
     found = False
     for resource in resources:
@@ -64,6 +64,7 @@ if '\"error_code\":\"403\"' not in response.text:
     if (found == False):
         dbutils.notebook.exit("The configured SQL Warehouse Endpoint is not found.")    
 else:
+    loggr.info(f"Error with PAT token, {response.text}")    
     dbutils.notebook.exit("Invalid access token, check PAT configuration value for this workspace.")            
 
 

--- a/notebooks/Setup/5. import_dashboard_template_lakeview.py
+++ b/notebooks/Setup/5. import_dashboard_template_lakeview.py
@@ -52,7 +52,7 @@ response = requests.get(
           json=None,
           timeout=60 
         )
-if '\"error_code\":\"403\"' not in response.text:
+if response.status_code == 200:
     resources = json.loads(response.text)
     found = False
     for resource in resources:
@@ -64,6 +64,7 @@ if '\"error_code\":\"403\"' not in response.text:
     if (found == False):
         dbutils.notebook.exit("The configured SQL Warehouse Endpoint is not found.")    
 else:
+    loggr.info(f"Error with PAT token, {response.text}")
     dbutils.notebook.exit("Invalid access token, check PAT configuration value for this workspace.")            
 
 


### PR DESCRIPTION
If the API call fails then the current IF statement isn't picking this up and the error is displayed correctly.  This fixes that by checking for a valid 200 response and logs any invalid responses.