### PR TITLE
fix(terraform-common): Remove "/Workspace" prefix from databricks repo

### DIFF
--- a/terraform/common/repo.tf
+++ b/terraform/common/repo.tf
@@ -3,5 +3,5 @@
 resource "databricks_repo" "security_analysis_tool" {
   url    = "https://github.com/databricks-industry-solutions/security-analysis-tool.git"
   branch = "main"
-  path   = "/Workspace/Applications/SAT_TF"
+  path   = "/Applications/SAT_TF"
 }


### PR DESCRIPTION
Remove "/Workspace" prefix from the databricks_repo resource to prevent Terraform from getting stuck in drift.