### PR TITLE
Feature/SFE-3755 - Workspace ID as a parameter in diagnostics

### DIFF
--- a/notebooks/diagnosis/sat_diagnosis_aws.py
+++ b/notebooks/diagnosis/sat_diagnosis_aws.py
@@ -5,6 +5,21 @@
 
 # COMMAND ----------
 
+# MAGIC %md
+# MAGIC ### Widget to provide specific workspace URL for connectivity tests
+# MAGIC If you need to test connectivity to specific workspaces, the following code would create a new widget to accept the workspace URL as a parameter. If this widget is left empty it connects to the current workspace (default). A sample workspace URL that can be provided through the widget (if needed) is given below.
+# MAGIC
+# MAGIC * dbc-xxxxxxxx-xxxx.cloud.databricks.com
+
+# COMMAND ----------
+
+# Create the text input widget for workspace url, assign it to a variable and print it
+dbutils.widgets.text("workspaceUrl", "")
+userWorkspaceUrl = dbutils.widgets.get("workspaceUrl")
+print("User provided workspace URL ->", userWorkspaceUrl)
+
+# COMMAND ----------
+
 # MAGIC %run ../Includes/install_sat_sdk
 
 # COMMAND ----------
@@ -72,7 +87,9 @@ for key in dbutils.secrets.list(sat_scope):
 # COMMAND ----------
 
 # Define the URL and headers
-workspaceUrl = spark.conf.get('spark.databricks.workspaceUrl')
+#workspaceUrl = spark.conf.get('spark.databricks.workspaceUrl')
+# Use the workspace variable provided or fallback to the default workspace url
+workspaceUrl = userWorkspaceUrl or spark.conf.get("spark.databricks.workspaceUrl")
 
 import requests
 

--- a/notebooks/diagnosis/sat_diagnosis_azure.py
+++ b/notebooks/diagnosis/sat_diagnosis_azure.py
@@ -6,6 +6,21 @@
 
 # COMMAND ----------
 
+# MAGIC %md
+# MAGIC ### Widget to provide specific workspace URL for connectivity tests
+# MAGIC If you need to test connectivity to specific workspaces, the following code would create a new widget to accept the workspace URL as a parameter. If this widget is left empty it connects to the current workspace (default). A sample workspace URL that can be provided through the widget (if needed) is given below.
+# MAGIC
+# MAGIC * adb-1234567899876543.2.azuredatabricks.net
+
+# COMMAND ----------
+
+# Create the text input widget for workspace url, assign it to a variable and print it
+dbutils.widgets.text("workspaceUrl", "")
+userWorkspaceUrl = dbutils.widgets.get("workspaceUrl")
+print("User provided workspace URL ->", userWorkspaceUrl)
+
+# COMMAND ----------
+
 # MAGIC %run ../Includes/install_sat_sdk
 
 # COMMAND ----------
@@ -114,7 +129,9 @@ import requests
 
 
 # Define the URL and headers
-workspaceUrl = spark.conf.get('spark.databricks.workspaceUrl')
+#workspaceUrl = spark.conf.get('spark.databricks.workspaceUrl')
+# Use the workspace variable provided or fallback to the default workspace url
+workspaceUrl = userWorkspaceUrl or spark.conf.get("spark.databricks.workspaceUrl")
 
 
 url = f'https://{workspaceUrl}/api/2.0/clusters/spark-versions'

--- a/notebooks/diagnosis/sat_diagnosis_gcp.py
+++ b/notebooks/diagnosis/sat_diagnosis_gcp.py
@@ -5,6 +5,21 @@
 
 # COMMAND ----------
 
+# MAGIC %md
+# MAGIC ### Widget to provide specific workspace URL for connectivity tests
+# MAGIC If you need to test connectivity to specific workspaces, the following code would create a new widget to accept the workspace URL as a parameter. A sample workspace URL that can be provided through the widget (if needed) is given below.
+# MAGIC
+# MAGIC * 1234567899876543.7.gcp.databricks.com
+
+# COMMAND ----------
+
+# Create the text input widget for workspace url, assign it to a variable and print it
+dbutils.widgets.text("workspaceUrl", "")
+userWorkspaceUrl = dbutils.widgets.get("workspaceUrl")
+print("User provided workspace URL ->", userWorkspaceUrl)
+
+# COMMAND ----------
+
 # MAGIC %run ../Includes/install_sat_sdk
 
 # COMMAND ----------
@@ -69,8 +84,9 @@ import requests,json
 # Define the URL and headers
 #workspaceUrl = spark.conf.get('spark.databricks.workspaceUrl')
 
-workspaceUrl =  "<>" #without http
-
+#workspaceUrl =  "<>" #without http
+# Use the workspace variable provided
+workspaceUrl = userWorkspaceUrl
 
 # COMMAND ----------
 


### PR DESCRIPTION
SFE-3755 -> Update diagnostic notebooks in all the three clouds to take workspace name as parameter instead of current workspace.