### PR TITLE
Updating hostname from ShardURL to WorkspaceURL

### DIFF
--- a/notebooks/Setup/1. list_account_workspaces_to_conf_file.py
+++ b/notebooks/Setup/1. list_account_workspaces_to_conf_file.py
@@ -22,7 +22,7 @@ hostname = (
     dbutils.notebook.entry_point.getDbutils()
     .notebook()
     .getContext()
-    .apiUrl()
+    .browserHostName()
     .getOrElse(None)
 )
 cloud_type = getCloudType(hostname)

--- a/notebooks/Setup/3. test_connections.py
+++ b/notebooks/Setup/3. test_connections.py
@@ -17,7 +17,13 @@
 
 # COMMAND ----------
 
-hostname = dbutils.notebook.entry_point.getDbutils().notebook().getContext().apiUrl().getOrElse(None)
+hostname = (
+  dbutils.notebook.entry_point.getDbutils()
+  .notebook()
+  .getContext()
+  .browserHostName()
+  .getOrElse(None)
+)
 cloud_type = getCloudType(hostname)
 clusterid = spark.conf.get("spark.databricks.clusterUsageTags.clusterId")
 

--- a/notebooks/Setup/5. import_dashboard_template_lakeview.py
+++ b/notebooks/Setup/5. import_dashboard_template_lakeview.py
@@ -27,7 +27,13 @@ current_workspace = get_context().workspaceId
 
 # COMMAND ----------
 
-hostname = dbutils.notebook.entry_point.getDbutils().notebook().getContext().apiUrl().getOrElse(None)
+hostname = (
+    dbutils.notebook.entry_point.getDbutils()
+    .notebook()
+    .getContext()
+    .browserHostName()
+    .getOrElse(None)
+)
 cloud_type = getCloudType(hostname)
 clusterid = spark.conf.get("spark.databricks.clusterUsageTags.clusterId")
 

--- a/notebooks/Setup/6. configure_alerts_template.py
+++ b/notebooks/Setup/6. configure_alerts_template.py
@@ -22,7 +22,13 @@ dfexist.filter((dfexist.analysis_enabled==True) & (dfexist.connection_test==True
 
 # COMMAND ----------
 
-hostname = dbutils.notebook.entry_point.getDbutils().notebook().getContext().apiUrl().getOrElse(None)
+hostname = (
+    dbutils.notebook.entry_point.getDbutils()
+    .notebook()
+    .getContext()
+    .browserHostName()
+    .getOrElse(None)
+)
 cloud_type = getCloudType(hostname)
 clusterid = spark.conf.get("spark.databricks.clusterUsageTags.clusterId")
 

--- a/notebooks/Setup/gcp/configure_sa_auth_tokens.py
+++ b/notebooks/Setup/gcp/configure_sa_auth_tokens.py
@@ -48,7 +48,13 @@ secret_scope_initial_manage_principal ='users'
 account_id = json_["account_id"] 
 
 
-hostname = dbutils.notebook.entry_point.getDbutils().notebook().getContext().apiUrl().getOrElse(None)
+hostname = (
+    dbutils.notebook.entry_point.getDbutils()
+    .notebook()
+    .getContext()
+    .browserHostName()
+    .getOrElse(None)
+)
 cloud_type = getCloudType(hostname)
 gcp_accounts_url = 'https://accounts.'+cloud_type+'.databricks.com'
 loggr.info(f" GCP account URL: {gcp_accounts_url}")

--- a/notebooks/Setup/gcp/configure_tokens_for_worksaces.py
+++ b/notebooks/Setup/gcp/configure_tokens_for_worksaces.py
@@ -49,7 +49,13 @@ except Exception:
     loggr.exception("Exception encountered")
 loggr.info(f"Renewing token for workspace")
 
-hostname = dbutils.notebook.entry_point.getDbutils().notebook().getContext().apiUrl().getOrElse(None)
+hostname = (
+  dbutils.notebook.entry_point.getDbutils()
+  .notebook()
+  .getContext()
+  .browserHostName()
+  .getOrElse(None)
+)
 cloud_type = getCloudType(hostname)
 
 # COMMAND ----------
@@ -59,7 +65,13 @@ mastername = dbutils.secrets.get(json_['master_name_scope'], json_['master_name_
 masterpwd = dbutils.secrets.get(json_['master_pwd_scope'], json_['master_pwd_key'])
 account_id=json_["account_id"]
 #replace values for accounts exec
-hostname = dbutils.notebook.entry_point.getDbutils().notebook().getContext().apiUrl().getOrElse(None)
+hostname = (
+  dbutils.notebook.entry_point.getDbutils()
+  .notebook()
+  .getContext()
+  .browserHostName()
+  .getOrElse(None)
+)
 cloud_type = getCloudType(hostname)
 gcp_accounts_url = 'https://accounts.'+cloud_type+'.databricks.com'
 

--- a/notebooks/Utils/accounts_bootstrap.py
+++ b/notebooks/Utils/accounts_bootstrap.py
@@ -43,7 +43,13 @@ loggr = LoggingUtils.get_logger()
 
 # COMMAND ----------
 
-hostname = dbutils.notebook.entry_point.getDbutils().notebook().getContext().apiUrl().getOrElse(None)
+hostname = (
+   dbutils.notebook.entry_point.getDbutils()
+   .notebook()
+   .getContext()
+   .browserHostName()
+   .getOrElse(None)
+)
 cloud_type = getCloudType(hostname)
 
 # COMMAND ----------

--- a/notebooks/Utils/common.py
+++ b/notebooks/Utils/common.py
@@ -257,7 +257,7 @@ def readBestPracticesConfigsFile():
             dbutils.notebook.entry_point.getDbutils()
             .notebook()
             .getContext()
-            .apiUrl()
+            .browserHostName()
             .getOrElse(None)
         )
         cloud_type = getCloudType(hostname)

--- a/notebooks/Utils/initialize.py
+++ b/notebooks/Utils/initialize.py
@@ -14,7 +14,7 @@ hostname = (
     dbutils.notebook.entry_point.getDbutils()
     .notebook()
     .getContext()
-    .apiUrl()
+    .browserHostName()
     .getOrElse(None)
 )
 cloud_type = getCloudType(hostname)

--- a/notebooks/Utils/sat_checks_config.py
+++ b/notebooks/Utils/sat_checks_config.py
@@ -82,7 +82,7 @@ def get_all_sat_checks():
         dbutils.notebook.entry_point.getDbutils()
         .notebook()
         .getContext()
-        .apiUrl()
+        .browserHostName()
         .getOrElse(None)
     )
     cloud_type = getCloudType(hostname)

--- a/notebooks/Utils/workspace_bootstrap.py
+++ b/notebooks/Utils/workspace_bootstrap.py
@@ -49,7 +49,13 @@ loggr.info('-----------------')
 
 # COMMAND ----------
 
-hostname = dbutils.notebook.entry_point.getDbutils().notebook().getContext().apiUrl().getOrElse(None)
+hostname = (
+    dbutils.notebook.entry_point.getDbutils()
+    .notebook()
+    .getContext()
+    .browserHostName()
+    .getOrElse(None)
+)
 cloud_type = getCloudType(hostname)
 workspace_id = json_['workspace_id']
 

--- a/notebooks/diagnosis/pre_run_config_check.py
+++ b/notebooks/diagnosis/pre_run_config_check.py
@@ -46,7 +46,7 @@ hostname = (
     dbutils.notebook.entry_point.getDbutils()
     .notebook()
     .getContext()
-    .apiUrl()
+    .browserHostName()
     .getOrElse(None)
 )
 cloud_type = getCloudType(hostname)

--- a/notebooks/security_analysis_driver.py
+++ b/notebooks/security_analysis_driver.py
@@ -27,7 +27,7 @@ hostname = (
     dbutils.notebook.entry_point.getDbutils()
     .notebook()
     .getContext()
-    .apiUrl()
+    .browserHostName()
     .getOrElse(None)
 )
 cloud_type = getCloudType(hostname)

--- a/notebooks/security_analysis_initializer.py
+++ b/notebooks/security_analysis_initializer.py
@@ -26,7 +26,7 @@ hostname = (
     dbutils.notebook.entry_point.getDbutils()
     .notebook()
     .getContext()
-    .apiUrl()
+    .browserHostName()
     .getOrElse(None)
 )
 cloud_type = getCloudType(hostname)


### PR DESCRIPTION
    dbutils.notebook.entry_point.getDbutils()
    .notebook()
    .getContext()
    .apiUrl()
    .getOrElse(None)
returns ShardURL.
This can be an issue in workspaces which have a firewall and block connection to ShardURL as ShardURL is not documented.

Hence, Can we update this to get WorkspaceURL instead?
    dbutils.notebook.entry_point.getDbutils()
    .notebook()
    .getContext()
    .browserHostName()
    .getOrElse(None)

This returns WorkspaceURL