### PR TITLE
updated query to fix false positive VNET Check

### DIFF
--- a/notebooks/Includes/workspace_analysis.py
+++ b/notebooks/Includes/workspace_analysis.py
@@ -190,7 +190,7 @@ if enabled:
     sql = f'''
         SELECT *
         FROM {tbl_name}
-        WHERE network_id is not null AND workspace_id ="{workspaceId}"
+        WHERE network_id is not null AND network_id != '' AND workspace_id ="{workspaceId}"
     '''
     sqlctrl(workspace_id, sql, byopc)
 


### PR DESCRIPTION
Fix: correct BYOVPC check to properly identify VNet-injected workspaces

- Fix SQL query to filter out empty string network_id values
- Prevents false positives where non-VNet workspaces were marked as VNet-injected
- Ensures accurate Network Security category reporting in the SAT dashboard