### PR TITLE
updating check logic for metastore owner

### DIFF
--- a/notebooks/Includes/workspace_analysis.py
+++ b/notebooks/Includes/workspace_analysis.py
@@ -1206,11 +1206,13 @@ def uc_metastore_owner(df):
     else:
         return (check_id, 0, {})   
 if enabled:    
-    tbl_name = 'unitycatalogmsv1' + '_' + workspace_id
+    tbl_name = 'workspace_metastore_summary' + '_' + workspace_id
     sql=f'''
-        SELECT name,owner,created_by
-        FROM {tbl_name} 
-        WHERE securable_type = 'METASTORE' and owner == created_by
+        SELECT m.name, m.owner, m.created_by
+        FROM {tbl_name} m
+        WHERE m.owner == m.created_by 
+           OR m.owner = 'System user'
+           OR m.owner LIKE '%@%'
     '''
     sqlctrl(workspace_id, sql, uc_metastore_owner)
  


### PR DESCRIPTION
Fix: Updating the check for UC Metastore ownership to correctly identify groups

- Check the correct table (workspace_metastore_summary) for the current workspace metastore
- Updated the logic to ensure that the metastore owner is not empty ("System user") or is not just another local user (identified via an email). 