### PR TITLE
Fix missing template variables in DABs bundle init

### DIFF
--- a/dabs/dabs_template/databricks_template_schema.json
+++ b/dabs/dabs_template/databricks_template_schema.json
@@ -20,6 +20,18 @@
         "serverless": {
             "type": "boolean",
             "description": "Serverless"
+        },
+        "is_service_principal": {
+            "type": "boolean",
+            "description": "Whether the current identity is a service principal"
+        },
+        "user_name": {
+            "type": "string",
+            "description": "User name or service principal application ID"
+        },
+        "workspace_host": {
+            "type": "string",
+            "description": "Databricks workspace host URL"
         }
     },
     "success_message": ""

--- a/dabs/dabs_template/template/tmp/databricks.yml.tmpl
+++ b/dabs/dabs_template/template/tmp/databricks.yml.tmpl
@@ -9,11 +9,11 @@ targets:
     default: true
     mode: production
     workspace:
-      host: {{workspace_host}}
+      host: {{.workspace_host}}
       root_path: /Applications/${bundle.name}/
     run_as:
-      {{- if is_service_principal}}
-      service_principal_name: {{user_name}}
+      {{- if .is_service_principal}}
+      service_principal_name: {{.user_name}}
       {{- else}}
-      user_name: {{user_name}}
+      user_name: {{.user_name}}
       {{- end}}

--- a/dabs/main.py
+++ b/dabs/main.py
@@ -10,6 +10,12 @@ from sat.utils import cloud_type
 def install(client: WorkspaceClient, answers: dict, profile: str):
     cloud = cloud_type(client)
     generate_secrets(client, answers, cloud)
+
+    # Determine current identity for run_as configuration
+    current_user = client.current_user.me()
+    is_sp = current_user.user_name and "@" not in current_user.user_name
+    user_name = current_user.user_name
+
     config = {
         "catalog": answers.get("catalog", None),
         "cloud": cloud,
@@ -25,6 +31,9 @@ def install(client: WorkspaceClient, answers: dict, profile: str):
             photon_worker_capable=True,
         ),
         "serverless": answers.get("enable_serverless", False),
+        "is_service_principal": is_sp,
+        "user_name": user_name,
+        "workspace_host": client.config.host,
     }
 
     config_file = "tmp_config.json"


### PR DESCRIPTION
## Description

The DABs installer fails when the `.databrickscfg` profile authenticates as a service principal. The `databricks.yml.tmpl` template references three variables (`is_service_principal`, `user_name`, `workspace_host`) that were neither declared in the template schema nor populated in the config file, causing `databricks bundle init` to fail with:

```
Error: failed to compute file content for tmp/databricks.yml.tmpl. variable "is_service_principal" not defined
./setup.sh: line 12: cd: tmp: No such file or directory
Error: unable to locate bundle root: databricks.yml not found
```

Additionally, the template used incorrect Go template syntax — `{{workspace_host}}` instead of `{{.workspace_host}}`.

**Fix:**
- Added the three missing variable declarations (`is_service_principal`, `user_name`, `workspace_host`) to the template schema
- Fixed Go template syntax in `databricks.yml.tmpl` (added `.` prefix to all variable references)
- Added auto-detection of the current identity in `main.py` using `client.current_user.me()`, which determines whether the caller is a service principal or a regular user and sets `run_as` accordingly

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Reproduced the original error by running `./install.sh` with a service principal profile
- Verified the config file contents via debug instrumentation to confirm the missing variables
- Confirmed `databricks bundle init` was failing with exit code 1 and the output directory was not being created
- Applied the fix and verified successful deployment with both user and service principal authentication

## Checklist
- [x] I have reviewed the [CONTRIBUTING](https://github.com/databricks-industry-solutions/security-analysis-tool/blob/main/CONTRIBUTING.md) and [VERSIONING](https://github.com/databricks-industry-solutions/security-analysis-tool/blob/main/VERSIONING.md) documentation.
- [x] My code follows the code style of this project.
- [x] I have verified, added or updated the tests to cover my changes (if applicable).
- [x] I have verified that my changes do not introduce any breaking changes on all the supported clouds (AWS, Azure, GCP).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (if applicable).

## Additional Notes
- The identity detection heuristic (`"@" not in user_name`) relies on the fact that service principals have UUID-format usernames while regular users have email addresses. This is consistent with Databricks SCIM API behavior across all clouds.
- When authenticated as a regular user, `run_as` uses `user_name:`; when authenticated as a service principal, it uses `service_principal_name:`.