### PR TITLE
fix(GOV-34): accept MANAGED state for access system schema

### DIFF
--- a/notebooks/Includes/workspace_analysis.py
+++ b/notebooks/Includes/workspace_analysis.py
@@ -1311,19 +1311,21 @@ if enabled:
 
 check_id='105' #GOV-34,Governance,Monitor audit logs with system tables
 enabled, sbp_rec = getSecurityBestPracticeRecord(check_id, cloud_type)
-metastores= {} # hold all the metastores that have no 'access' schema with state ENABLE_COMPLETED
+metastores= {} # hold all the metastores that have no 'access' schema enabled (ENABLE_COMPLETED or MANAGED)
 def uc_systemschemas(df):
     if df is not None and not isEmpty(df):
-        return (check_id, 0, {'enable_serverless_compute':'access schema with state ENABLE_COMPLETED found'} )
+        return (check_id, 0, {'enable_serverless_compute':'access schema enabled (ENABLE_COMPLETED or MANAGED) found'} )
     else:
-        return (check_id, 1, {'enable_serverless_compute':'access schema with state ENABLE_COMPLETED not found'}) 
+        return (check_id, 1, {'enable_serverless_compute':'access schema not enabled (state not ENABLE_COMPLETED or MANAGED)'}) 
     
 if enabled:    
     tbl_name = 'systemschemas' + '_' + workspace_id
+    # API returns "schema" and "state". Access schema can be ENABLE_COMPLETED or MANAGED (default-enabled).
     sql=f'''
         SELECT *
         FROM {tbl_name} 
-        where schema ="access" and state ="ENABLE_COMPLETED"
+        WHERE schema = "access"
+          AND (state = "ENABLE_COMPLETED" OR state = "MANAGED")
     '''
     sqlctrl(workspace_id, sql, uc_systemschemas)
 


### PR DESCRIPTION
## Description
GOV-34 ("Monitor audit logs with system tables") was failing for workspaces where the **access** system schema is enabled by default. The check only treated `state = "ENABLE_COMPLETED"` as passing; in many workspaces the List system schemas API returns `state = "MANAGED"` for the access schema when system tables are enabled by default.

This change updates the GOV-34 check so it passes when the **access** schema is present with **either** `ENABLE_COMPLETED` **or** `MANAGED`, since both indicate the schema is available for audit monitoring.

**Root cause:** The Databricks API `GET /api/2.1/unity-catalog/metastores/{metastore_id}/systemschemas` returns `schema` and `state`. For default-enabled system tables, the access schema often has `state: "MANAGED"` instead of `"ENABLE_COMPLETED"`. Example API response:

```json
{
  "schemas": [
    {
      "schema": "access",
      "state": "MANAGED"
    },
    {
      "schema": "billing",
      "state": "MANAGED"
    },
    ...
    {
      "schema": "information_schema",
      "state": "ENABLE_COMPLETED"
    }
  ]
}
```

**Code change:** In `notebooks/Includes/workspace_analysis.py`, the GOV-34 SQL filter is updated from:
- `WHERE schema = "access" AND state = "ENABLE_COMPLETED"`
to:
- `WHERE schema = "access" AND (state = "ENABLE_COMPLETED" OR state = "MANAGED")`

Pass/fail messages are updated to mention both states.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (non-code changes like README or docs)

## How Has This Been Tested?
- Confirmed the List system schemas API response shape (`schema`, `state`) and that the access schema can have `state: "MANAGED"` when system tables are enabled by default.
- Manually verified the updated SQL logic: workspaces with access schema in `MANAGED` or `ENABLE_COMPLETED` now pass GOV-34; behavior for other states is unchanged.

## Checklist
- [x] I have reviewed the [CONTRIBUTING](https://github.com/databricks-industry-solutions/security-analysis-tool/blob/main/CONTRIBUTING.md) and [VERSIONING](https://github.com/databricks-industry-solutions/security-analysis-tool/blob/main/VERSIONING.md) documentation.
- [x] My code follows the code style of this project.
- [ ] I have verified, added or updated the tests to cover my changes (if applicable).
- [x] I have verified that my changes do not introduce any breaking changes on all the supported clouds (AWS, Azure, GCP).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (if applicable).

## Screenshots (If Applicable)
N/A — logic-only change in notebook SQL and result messages.

## Additional Notes
- No new dependencies or deployment changes.
- Workspaces that previously failed GOV-34 despite having system tables (including access) enabled will now pass. No change for workspaces where the access schema was already `ENABLE_COMPLETED`.

