### PR TITLE
pin serverless to Environment v5 + scope accounts bootstrap to SAT-enabled workspaces

### DIFF
--- a/dabs/dabs_template/template/tmp/resources/brickhound_job.yml.tmpl
+++ b/dabs/dabs_template/template/tmp/resources/brickhound_job.yml.tmpl
@@ -37,6 +37,8 @@ resources:
           libraries:
             - pypi:
                 package: networkx
+          {{- else }}
+          environment_key: "default"
           {{- end }}
           notebook_task:
             notebook_path: "/Workspace/Applications/SAT/files/notebooks/permission_analysis_data_collection"
@@ -55,5 +57,10 @@ resources:
               availability: SPOT_WITH_FALLBACK
               first_on_demand: 1
             {{- end }}
+      {{- else }}
+      environments:
+        - environment_key: "default"
+          spec:
+            client: "5"
       {{- end }}
 {{- end }}

--- a/dabs/dabs_template/template/tmp/resources/sat_driver_job.yml.tmpl
+++ b/dabs/dabs_template/template/tmp/resources/sat_driver_job.yml.tmpl
@@ -14,6 +14,8 @@ resources:
           libraries:
             - pypi:
                 package: dbl-sat-sdk
+          {{- else }}
+          environment_key: "default"
           {{- end }}
           notebook_task:
             notebook_path: "/Workspace/Applications/SAT/files/notebooks/security_analysis_driver"
@@ -32,4 +34,9 @@ resources:
               availability: SPOT_WITH_FALLBACK
               first_on_demand: 1
             {{- end }}
+      {{- else }}
+      environments:
+        - environment_key: "default"
+          spec:
+            client: "5"
       {{- end }}

--- a/dabs/dabs_template/template/tmp/resources/sat_initiliazer_job.yml.tmpl
+++ b/dabs/dabs_template/template/tmp/resources/sat_initiliazer_job.yml.tmpl
@@ -7,17 +7,19 @@ resources:
 
       tasks:
         - task_key: "sat_initializer"
-        
+
           {{- if eq .serverless false }}
           job_cluster_key: job_cluster
-          
+
           libraries:
             - pypi:
                 package: dbl-sat-sdk
+          {{- else }}
+          environment_key: "default"
           {{- end }}
           notebook_task:
             notebook_path: "/Workspace/Applications/SAT/files/notebooks/security_analysis_initializer"
-      
+
       {{- if eq .serverless false }}
       job_clusters:
         - job_cluster_key: job_cluster
@@ -32,4 +34,9 @@ resources:
               availability: SPOT_WITH_FALLBACK
               first_on_demand: 1
             {{- end }}
+      {{- else }}
+      environments:
+        - environment_key: "default"
+          spec:
+            client: "5"
       {{- end }}

--- a/dabs/dabs_template/template/tmp/resources/sat_secrets_scanner_job.yml.tmpl
+++ b/dabs/dabs_template/template/tmp/resources/sat_secrets_scanner_job.yml.tmpl
@@ -10,17 +10,19 @@ resources:
 
       tasks:
         - task_key: "secrets_scanner"
-        
+
           {{- if eq .serverless false }}
           job_cluster_key: job_cluster
-          
+
           libraries:
             - pypi:
                 package: dbl-sat-sdk
+          {{- else }}
+          environment_key: "default"
           {{- end }}
           notebook_task:
             notebook_path: "/Workspace/Applications/SAT/files/notebooks/security_analysis_secrets_scanner"
-      
+
       {{- if eq .serverless false }}
       job_clusters:
         - job_cluster_key: job_cluster
@@ -35,4 +37,9 @@ resources:
               availability: SPOT_WITH_FALLBACK
               first_on_demand: 1
             {{- end }}
+      {{- else }}
+      environments:
+        - environment_key: "default"
+          spec:
+            client: "5"
       {{- end }}

--- a/notebooks/Utils/accounts_bootstrap.py
+++ b/notebooks/Utils/accounts_bootstrap.py
@@ -289,9 +289,16 @@ except Exception:
 
 # Collect workspace network configurations
 # This links workspaces to their assigned network policies
+# Scope to SAT-enabled workspaces only (account_workspaces.analysis_enabled=true),
+# matching the driver's own workspace iteration at
+# security_analysis_driver.py:68 and avoiding N API calls for unused workspaces.
 try:
-    workspaces = spark.table('acctworkspaces').collect()
-    loggr.info(f"Collecting network configurations for {len(workspaces)} workspaces")
+    schema = json_['analysis_schema_name']
+    workspaces = spark.sql(
+        f"SELECT workspace_id FROM {schema}.account_workspaces "
+        f"WHERE analysis_enabled = true"
+    ).collect()
+    loggr.info(f"Collecting network configurations for {len(workspaces)} SAT-enabled workspaces")
     for ws in workspaces:
         workspace_id = str(ws.workspace_id)
         try:

--- a/terraform/common/brickhound_job.tf
+++ b/terraform/common/brickhound_job.tf
@@ -39,9 +39,20 @@ resource "databricks_job" "brickhound_data_collection" {
     }
   }
 
+  dynamic "environment" {
+    for_each = var.run_on_serverless ? [1] : []
+    content {
+      environment_key = "default"
+      spec {
+        client = "5"
+      }
+    }
+  }
+
   task {
     task_key        = "BrickHoundDataCollection"
     job_cluster_key = var.run_on_serverless ? null : "brickhound_cluster"
+    environment_key = var.run_on_serverless ? "default" : null
 
     notebook_task {
       notebook_path = "${databricks_repo.security_analysis_tool.path}/notebooks/permission_analysis_data_collection"

--- a/terraform/common/jobs.tf
+++ b/terraform/common/jobs.tf
@@ -30,9 +30,20 @@ resource "databricks_job" "initializer" {
     }
   }
 
+  dynamic "environment" {
+    for_each = var.run_on_serverless ? [1] : []
+    content {
+      environment_key = "default"
+      spec {
+        client = "5"
+      }
+    }
+  }
+
   task {
     task_key        = "Initializer"
     job_cluster_key = var.run_on_serverless ? null : "job_cluster"
+    environment_key = var.run_on_serverless ? "default" : null
     dynamic "library" {
       for_each = var.run_on_serverless ? [] : [1]
       content {
@@ -80,10 +91,20 @@ resource "databricks_job" "driver" {
     }
   }
 
+  dynamic "environment" {
+    for_each = var.run_on_serverless ? [1] : []
+    content {
+      environment_key = "default"
+      spec {
+        client = "5"
+      }
+    }
+  }
 
   task {
     task_key        = "Driver"
     job_cluster_key = var.run_on_serverless ? null : "job_cluster"
+    environment_key = var.run_on_serverless ? "default" : null
     dynamic "library" {
       for_each = var.run_on_serverless ? [] : [1]
       content {
@@ -138,9 +159,20 @@ resource "databricks_job" "secrets_scanner" {
     }
   }
 
+  dynamic "environment" {
+    for_each = var.run_on_serverless ? [1] : []
+    content {
+      environment_key = "default"
+      spec {
+        client = "5"
+      }
+    }
+  }
+
   task {
     task_key        = "secrets_scanner"
     job_cluster_key = var.run_on_serverless ? null : "job_cluster"
+    environment_key = var.run_on_serverless ? "default" : null
     dynamic "library" {
       for_each = var.run_on_serverless ? [] : [1]
       content {


### PR DESCRIPTION
## Summary

Two changes surfaced by Azure end-to-end testing of `release/0.8.0`:

1. **Pin serverless tasks to Environment v5.** DABS templates (driver, initializer, secrets scanner, brickhound) and the equivalent Terraform job resources (`terraform/common/jobs.tf`, `terraform/common/brickhound_job.tf`) now emit `environment_key: "default"` with a matching `environments:` block specifying `client: "5"` whenever serverless is selected. Classic compute paths are unchanged.

2. **Scope the accounts_bootstrap network-config loop to SAT-enabled workspaces.** `notebooks/Utils/accounts_bootstrap.py` previously iterated every workspace in the account (`acctworkspaces`) when fetching per-workspace network configuration. It now queries `account_workspaces.analysis_enabled = true` — matching the driver's own workspace iteration (`security_analysis_driver.py:68`) and avoiding N unnecessary REST calls on accounts with many non-SAT workspaces. Applies to both classic and serverless runs.

## Test plan

- [x] \`terraform validate\` passes on \`terraform/aws\`, \`terraform/azure\`, \`terraform/gcp\`
- [x] DABS templates render cleanly under \`serverless: true\` and \`serverless: false\`
- [x] End-to-end Azure serverless run completed; jobs confirmed running on Environment v5
- [x] \`codespell\` clean across both commits
- [ ] Merge into \`release/0.8.0\`, then the existing release→main merge continues as planned

This pull request was AI-assisted by Isaac.