### PR TITLE
docs: 0.8.0 release updates (check count, secret scanning, troubleshooting, upgrade guide, NS-14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The **Security Analysis Tool (SAT)** analyzes your Databricks account and workspace configurations, providing recommendations to help you follow Databricks' security best practices.
 
+**Latest version:** [v0.8.0](https://github.com/databricks-industry-solutions/security-analysis-tool/releases) — live egress testing, per-user identity in Permissions Analysis, expanded secret scanning, and 11 new checks. See the [Upgrade Guide](https://databricks-industry-solutions.github.io/security-analysis-tool/docs/upgrade) for behavior changes when upgrading from 0.7.x.
+
 ## Documentation
 
 Refer to the [SAT documentation](https://databricks-industry-solutions.github.io/security-analysis-tool/) for detailed information on how to use SAT, its features, and configuration options.

--- a/docs/sat/docs/functionality/cluster-secrets-scanning.mdx
+++ b/docs/sat/docs/functionality/cluster-secrets-scanning.mdx
@@ -16,7 +16,13 @@ Developers sometimes hardcode credentials in cluster environment variables durin
 
 ## What It Does
 
-SAT scans `spark_env_vars` in cluster configurations for hardcoded credentials using TruffleHog with 800+ detector patterns, including:
+SAT scans cluster configurations and the artifacts they reference for hardcoded credentials using TruffleHog with 800+ detector patterns:
+
+- **`spark_env_vars`** — environment variables set on the cluster.
+- **Cluster init scripts** — including init scripts referenced via FUSE mount paths (`/Volumes/...`, `/dbfs/...`). Scanned as files, so secrets embedded in shell scripts are detected, not just string-literal env values.
+- **Notebook content** — companion notebook scan covered on the [main usage page](/docs/usage#configuring-secret-scanning-optional).
+
+Detection covers:
 
 - **AWS credentials**: Access keys, secret keys, session tokens
 - **Azure secrets**: Service principal keys, storage account keys
@@ -26,6 +32,12 @@ SAT scans `spark_env_vars` in cluster configurations for hardcoded credentials u
 - **Database passwords**: Connection strings with embedded credentials
 - **Private keys**: SSH keys, RSA keys, and other cryptographic material
 - **Databricks-specific tokens**: DKEA, DAPI, DOSE tokens
+
+<Admonition type="info" title="0.8.0 improvements">
+- Init scripts referenced via FUSE mount paths are now part of the scan.
+- The `DetectorName` field on findings is now consistently populated (was sometimes missing on older runs).
+- TruffleHog is installed from a pinned tagged release for supply-chain reproducibility — no more drift from upstream `master`.
+</Admonition>
 
 ## Why It Matters
 

--- a/docs/sat/docs/functionality/index.mdx
+++ b/docs/sat/docs/functionality/index.mdx
@@ -60,13 +60,15 @@ SAT is typically run daily as an automated workflow within your environment:
 
 ## Security Categories
 
-SAT evaluates over **60 security best practices** across five key categories:
+SAT evaluates **65+ security best practices** across five key categories:
 
-* **Network Security** - Network policies, VPC configurations, and network isolation
+* **Network Security** - Network policies, VPC configurations, and network isolation (includes live egress testing from compute as of 0.8.0)
 * **Identity & Access** - User management, group memberships, and access controls
 * **Data Protection** - Encryption, data classification, and data governance
 * **Governance** - Compliance, audit logging, and policy enforcement
 * **Informational** - Observations and recommendations for continuous improvement
+
+Cloud applicability for each check is recorded in `configs/security_best_practices.csv` — a small number of checks are AWS-only or AWS+GCP-only where the underlying API is not available on every cloud.
 
 **Severity Levels:**
 * **High** - Critical issues requiring immediate attention

--- a/docs/sat/docs/functionality/index.mdx
+++ b/docs/sat/docs/functionality/index.mdx
@@ -14,7 +14,7 @@ The **Security Analysis Tool (SAT)** is an observability utility designed to imp
 
 - **11 new checks** across Data Protection, Governance, Identity & Access, Network Security, and Informational.
 - **Live egress testing (NS-14)** — first SAT check that probes real network behavior from compute, not just configuration.
-- **Per-user identity in Permissions Analysis** — the BrickHound app now runs queries as the calling user; Unity Catalog enforces grants directly.
+- **Per-user identity in Permissions Analysis** — the app now runs queries as the calling user; Unity Catalog enforces grants directly.
 - **Expanded secret scanning** — cluster init scripts referenced via FUSE mounts are now scanned alongside `spark_env_vars`.
 - See the [Upgrade Guide](../upgrade) for behavior changes when upgrading from 0.7.x.
 

--- a/docs/sat/docs/functionality/index.mdx
+++ b/docs/sat/docs/functionality/index.mdx
@@ -10,6 +10,16 @@ import FeatureCards from '@site/src/components/FeatureCards';
 
 The **Security Analysis Tool (SAT)** is an observability utility designed to improve the security posture of Databricks deployments. It helps you identify deviations from established security best practices and monitor the security health of your Databricks workspaces.
 
+<Admonition type="tip" title="What's new in 0.8.0">
+
+- **11 new checks** across Data Protection, Governance, Identity & Access, Network Security, and Informational.
+- **Live egress testing (NS-14)** — first SAT check that probes real network behavior from compute, not just configuration.
+- **Per-user identity in Permissions Analysis** — the BrickHound app now runs queries as the calling user; Unity Catalog enforces grants directly.
+- **Expanded secret scanning** — cluster init scripts referenced via FUSE mounts are now scanned alongside `spark_env_vars`.
+- See the [Upgrade Guide](../upgrade) for behavior changes when upgrading from 0.7.x.
+
+</Admonition>
+
 <div className='bg-gray-100 p-4 rounded-lg mb-6'>
  <img src={useBaseUrl('/img/sat_functionality.png')} alt="SAT Functionality Overview" />
 </div>
@@ -74,6 +84,15 @@ Cloud applicability for each check is recorded in `configs/security_best_practic
 * **High** - Critical issues requiring immediate attention
 * **Medium** - Important issues to address soon
 * **Low** - Minor issues for continuous improvement
+
+### Live behavior tests (new in 0.8.0)
+
+Most SAT checks inspect configuration and report deviations. **NS-14** is the first SAT check that exercises real behavior — it runs from the SAT driver compute and probes a small set of public destinations to verify that egress controls actually block outbound traffic.
+
+* On a workspace with restrictive egress controls, the probes are *expected* to fail. NS-14 reports "egress blocked" — that's the **pass** state.
+* On a workspace with no egress restriction, the probes succeed and NS-14 reports the destinations as reachable.
+
+This makes NS-14 useful as a real-world spot check for egress configuration: it tells you whether your network controls are doing their job, not just whether they exist on paper.
 
 ---
 

--- a/docs/sat/docs/functionality/permissions-analysis.mdx
+++ b/docs/sat/docs/functionality/permissions-analysis.mdx
@@ -113,10 +113,10 @@ is required.
 
 When user authorization is configured, the app constructs a per-request
 `WorkspaceClient` bound to the caller's forwarded OAuth token and Unity
-Catalog enforces the caller's grants on the BrickHound tables.
+Catalog enforces the caller's grants on the Permissions Analysis tables.
 
 **Required Unity Catalog grants (admin-only).** Grant the users or
-group who will run permissions analyses `SELECT` on the three BrickHound
+group who will run permissions analyses `SELECT` on the three Permissions Analysis
 tables in the SAT analysis schema, e.g.:
 
 ```sql
@@ -141,7 +141,7 @@ the missing tables instead of a generic error.
 
 #### Upgrading from SAT 0.7.x
 
-If you are upgrading an existing SAT install (where the BrickHound app
+If you are upgrading an existing SAT install (where the Permissions Analysis app
 ran without user authorization), each user who had previously opened
 the app needs to re-consent once. They will see the friendly "missing
 the `sql` scope" banner until they do. Three workarounds, easiest first:

--- a/docs/sat/docs/installation/terraform/index.mdx
+++ b/docs/sat/docs/installation/terraform/index.mdx
@@ -28,13 +28,13 @@ SAT can be set up on any of the cloud platforms where Databricks is hosted using
 
 ## Permissions Analysis Setup
 
-After installing SAT, you will need to manually complete the Permissions Analysis app deployment and configuration by following these steps:
+After installing SAT, complete the Permissions Analysis app setup as follows:
 
 ### 1. Deploy the app using the Databricks CLI
 
-Deploy the app using the appropriate command based on your installation method:
+Deploy the app source code to the running app:
 
-**For DABs installations:**
+**For DABS installations:**
 ```bash
 databricks apps deploy sat-permissions-exp --source-code-path /Workspace/Applications/SAT/files/app/brickhound
 ```
@@ -42,44 +42,33 @@ databricks apps deploy sat-permissions-exp --source-code-path /Workspace/Applica
 **For Terraform installations:**
 ```bash
 databricks apps deploy sat-permissions-exp --source-code-path /Workspace/Repos/Applications/SAT_TF/app/brickhound
-databricks app deploy
 ```
 
 <Admonition type="note" title="Note">
 The app compute may take a few minutes to start. Please make sure that **Compute > Apps > sat-permissions-exp** is "running" in your workspace before proceeding to the next step.
 </Admonition>
 
-### 2. Configure app resources
+### 2. App resources and user authorization
 
-Edit the app configuration in the Databricks UI and assign the following resources:
+The SQL warehouse, secrets, and the `sql` user-authorization scope required by the app are declared automatically by the SAT install (Terraform's `databricks_app` resource and the equivalent DABS apps resource). **No manual UI configuration is required** for new installs.
 
-| Resource Type | Resource Key | Secret Scope | Secret Key | Value |
-|--------------|--------------|--------------|------------|-------|
-| SQL warehouse | `sql-warehouse` | — | — | — |
-| Secret | — | `sat_scope` | `sql-warehouse-id` | `sql-warehouse-id` |
-| Secret | — | `sat_scope` | `analysis_schema_name` | `analysis_schema_name` |
+To verify the configuration applied correctly, open **Compute → Apps → sat-permissions-exp → Edit** and confirm:
+
+| Section | Expected entries |
+|---|---|
+| App resources | `warehouse` (SQL warehouse, Can use), `analysis_schema_name` (secret, Can read), `sql-warehouse-id` (secret, Can read) |
+| User authorization | `sql` scope present |
 
 ### 3. Grant Unity Catalog permissions
 
-After running the jobs and before the first use of the app, you need to grant Unity Catalog permissions to the app's service principal.
-
-1. Copy the [App authorization service principal](https://docs.databricks.com/aws/en/dev-tools/databricks-apps/auth#app-authorization) (not the name, the actual service principal ID)
-2. Run the following SQL commands to grant the necessary permissions:
+The app uses on-behalf-of-user authentication, so each caller's queries run as that user — Unity Catalog enforces the caller's grants on the Permissions Analysis tables. Grant `SELECT` on those tables to the user(s) or group who will run permissions analyses:
 
 ```sql
--- Grant USE CATALOG permission
-GRANT USE CATALOG ON CATALOG <your SAT UC catalog>
-TO `<app authorization service principal>`;
-
--- Grant USE SCHEMA permission
-GRANT USE SCHEMA ON SCHEMA <your SAT UC catalog>.<SAT Schema>
-TO `<app authorization service principal>`;
-
--- Grant SELECT on all tables in the schema
-GRANT SELECT ON SCHEMA <your SAT UC catalog>.<SAT Schema>
-TO `<app authorization service principal>`;
+GRANT SELECT ON TABLE `<catalog>`.`<schema>`.brickhound_vertices             TO `<admin_group>`;
+GRANT SELECT ON TABLE `<catalog>`.`<schema>`.brickhound_edges                TO `<admin_group>`;
+GRANT SELECT ON TABLE `<catalog>`.`<schema>`.brickhound_collection_metadata  TO `<admin_group>`;
 ```
 
 <Admonition type="tip" title="Tip">
-Replace `<your SAT UC catalog>`, `<SAT Schema>`, and `<app authorization service principal>` with your actual values.
+Replace `<catalog>`, `<schema>`, and `<admin_group>` with the values used during your SAT install. The full setup, including the user-authorization scope and how the friendly no-access banner behaves, is documented on the [Permissions Analysis page](../../functionality/permissions-analysis.mdx#user-authorization).
 </Admonition>

--- a/docs/sat/docs/troubleshooting.mdx
+++ b/docs/sat/docs/troubleshooting.mdx
@@ -101,13 +101,13 @@ The Permissions Analysis app uses on-behalf-of-user (OBO) authentication in 0.8.
 2. Or clear cookies for the workspace domain in your regular browser, then reopen the app.
 3. Or revoke the prior authorization from your account profile (if your workspace exposes a "Linked apps" list), then reopen.
 
-The full background and permanent setup is on the [Permissions Analysis page](./functionality/permissions-analysis#configure-user-authorization-recommended).
+The full background and permanent setup is on the [Permissions Analysis page](./functionality/permissions-analysis.mdx#user-authorization).
 
 </AccordionItem>
 
 <AccordionItem question="Permissions Analysis app shows 'You don't have permission to read the SAT permissions analysis schema'">
 
-In 0.8.0 the app runs Statement Execution as the calling user, so Unity Catalog enforces the user's grants on the BrickHound tables. If the user does not have `SELECT` on those tables, the app renders a friendly banner instead of a SQL error.
+In 0.8.0 the app runs Statement Execution as the calling user, so Unity Catalog enforces the user's grants on the Permissions Analysis tables. If the user does not have `SELECT` on those tables, the app renders a friendly banner instead of a SQL error.
 
 **Resolution:** an admin grants `SELECT` on the three tables to the user or group that needs to use the app. Replace `<catalog>` and `<schema>` with the values used during your SAT install:
 

--- a/docs/sat/docs/troubleshooting.mdx
+++ b/docs/sat/docs/troubleshooting.mdx
@@ -91,6 +91,42 @@ If you don't see a JSON with a clean listing of workspaces, you are likely havin
 
 </AccordionItem>
 
+<AccordionItem question="Permissions Analysis app shows 'missing sql scope' banner after upgrading to 0.8.0">
+
+The Permissions Analysis app uses on-behalf-of-user (OBO) authentication in 0.8.0. The required `sql` scope is declared in the SAT install templates, but each user must consent to the scope on first open after the upgrade. If you opened the app before upgrading, your browser session has a cached consent grant without `sql` and you'll see the banner.
+
+**Resolution (try in order):**
+
+1. Open the app URL in a private/incognito window — this triggers a fresh consent prompt.
+2. Or clear cookies for the workspace domain in your regular browser, then reopen the app.
+3. Or revoke the prior authorization from your account profile (if your workspace exposes a "Linked apps" list), then reopen.
+
+The full background and permanent setup is on the [Permissions Analysis page](./functionality/permissions-analysis#configure-user-authorization-recommended).
+
+</AccordionItem>
+
+<AccordionItem question="Permissions Analysis app shows 'You don't have permission to read the SAT permissions analysis schema'">
+
+In 0.8.0 the app runs Statement Execution as the calling user, so Unity Catalog enforces the user's grants on the BrickHound tables. If the user does not have `SELECT` on those tables, the app renders a friendly banner instead of a SQL error.
+
+**Resolution:** an admin grants `SELECT` on the three tables to the user or group that needs to use the app. Replace `<catalog>` and `<schema>` with the values used during your SAT install:
+
+```sql
+GRANT SELECT ON TABLE `<catalog>`.`<schema>`.brickhound_vertices             TO `<admin_group>`;
+GRANT SELECT ON TABLE `<catalog>`.`<schema>`.brickhound_edges                TO `<admin_group>`;
+GRANT SELECT ON TABLE `<catalog>`.`<schema>`.brickhound_collection_metadata  TO `<admin_group>`;
+```
+
+</AccordionItem>
+
+<AccordionItem question="NS-14 (egress control) reports 'egress blocked' on workspaces with restricted egress">
+
+NS-14 is a live behavior check — it runs from the SAT driver compute and probes a small list of public destinations to confirm whether outbound traffic is reachable. On a properly egress-restricted network the probes are *expected* to fail, and **that's the pass state for the check**: egress controls are doing their job.
+
+If you see NS-14 reporting "egress blocked" on a workspace where you've configured network policies or firewall rules to restrict outbound traffic, no action is required.
+
+</AccordionItem>
+
 <AccordionItem question="Offline Library Install - No PyPI Access">
 
 If your workspace does not have access to PyPI, follow these steps to install the required libraries manually:

--- a/docs/sat/docs/upgrade.mdx
+++ b/docs/sat/docs/upgrade.mdx
@@ -5,7 +5,7 @@ import Admonition from '@theme/Admonition';
 
 # Upgrading SAT
 
-This page covers behavior changes you should expect when upgrading an existing SAT install to a newer version. SAT does not auto-upgrade — see the [FAQ](./faq#sat-deployment-and-support) for the rationale.
+This page covers behavior changes you should expect when upgrading an existing SAT install to a newer version. SAT does not auto-upgrade — see the [FAQ](./faq.mdx#sat-deployment-and-support) for the rationale.
 
 ## Upgrading from 0.7.x to 0.8.0
 
@@ -20,13 +20,13 @@ Re-deploy via your usual install path to pick up the 0.8.0 templates, new checks
 ### What you'll notice after the upgrade
 
 <Admonition type="info" title="One-time consent re-prompt for the Permissions Analysis app">
-The Permissions Analysis (BrickHound) app now uses on-behalf-of-user (OBO) authentication so Unity Catalog enforces each caller's grants on the BrickHound tables. The required `sql` scope is set automatically by the SAT install. **Existing users who opened the app before the upgrade will see a friendly "missing sql scope" banner once** — until they trigger a fresh OAuth consent prompt by opening the app in a private/incognito window or clearing cookies for the workspace domain. New users hit no prompt because consent fires automatically on first open.
+The Permissions Analysis app now uses on-behalf-of-user (OBO) authentication so Unity Catalog enforces each caller's grants on the Permissions Analysis tables. The required `sql` scope is set automatically by the SAT install. **Existing users who opened the app before the upgrade will see a friendly "missing sql scope" banner once** — until they trigger a fresh OAuth consent prompt by opening the app in a private/incognito window or clearing cookies for the workspace domain. New users hit no prompt because consent fires automatically on first open.
 
-Full setup on the [Permissions Analysis page](./functionality/permissions-analysis); workaround details in [Troubleshooting](./troubleshooting).
+Full setup on the [Permissions Analysis page](./functionality/permissions-analysis.mdx); workaround details in [Troubleshooting](./troubleshooting.mdx).
 </Admonition>
 
 <Admonition type="info" title="Dashboard check count goes up">
-0.8.0 adds new security checks across Data Protection, Governance, Identity & Access, Network Security, and Informational categories. Your dashboard rows will increase the first time the driver runs after the upgrade. Review the new findings against your security baseline — some may surface deviations that were previously not measured. You can disable any check via the `7. update_sat_check_configuration` notebook (see [Usage → Modifying Security Best Practices](./usage#modifying-security-best-practices)).
+0.8.0 adds new security checks across Data Protection, Governance, Identity & Access, Network Security, and Informational categories. Your dashboard rows will increase the first time the driver runs after the upgrade. Review the new findings against your security baseline — some may surface deviations that were previously not measured. You can disable any check via the `7. update_sat_check_configuration` notebook (see [Usage → Modifying Security Best Practices](./usage.mdx#modifying-security-best-practices)).
 </Admonition>
 
 <Admonition type="info" title="IA-9 no longer evaluated on Azure">
@@ -43,10 +43,10 @@ If you see fewer Identity & Access rows on Azure dashboards than before, this is
 
 - **SDK version**: SAT 0.8.0 ships `dbl_sat_sdk-0.1.51`. Re-deploy picks it up automatically; manual installs should reference the wheel under `lib/`.
 - **Serverless compute**: SAT jobs and the Permissions Analysis app pin to **Environment v5** for predictable behavior across DABS and Terraform installs.
-- **Secret scanner coverage**: cluster init scripts referenced via FUSE mount paths are now scanned alongside `spark_env_vars`. See [Cluster Secrets Scanning](./functionality/cluster-secrets-scanning).
+- **Secret scanner coverage**: cluster init scripts referenced via FUSE mount paths are now scanned alongside `spark_env_vars`. See [Cluster Secrets Scanning](./functionality/cluster-secrets-scanning.mdx).
 
 ### If something looks wrong
 
-- Run the diagnosis notebook for your cloud (`notebooks/diagnosis/sat_diagnosis_<cloud>.py`) — see [Troubleshooting](./troubleshooting).
-- Check the [Troubleshooting](./troubleshooting) page for entries on the BrickHound consent banner, missing UC SELECT, and NS-14 expected behavior.
+- Run the diagnosis notebook for your cloud (`notebooks/diagnosis/sat_diagnosis_<cloud>.py`) — see [Troubleshooting](./troubleshooting.mdx).
+- Check the [Troubleshooting](./troubleshooting.mdx) page for entries on the Permissions Analysis consent banner, missing UC SELECT, and NS-14 expected behavior.
 - Open a [GitHub Issue](https://github.com/databricks-industry-solutions/security-analysis-tool/issues) if you hit something not covered.

--- a/docs/sat/docs/upgrade.mdx
+++ b/docs/sat/docs/upgrade.mdx
@@ -1,0 +1,52 @@
+---
+sidebar_position: 4
+---
+import Admonition from '@theme/Admonition';
+
+# Upgrading SAT
+
+This page covers behavior changes you should expect when upgrading an existing SAT install to a newer version. SAT does not auto-upgrade — see the [FAQ](./faq#sat-deployment-and-support) for the rationale.
+
+## Upgrading from 0.7.x to 0.8.0
+
+### What to do
+
+Re-deploy via your usual install path to pick up the 0.8.0 templates, new checks, and SDK update:
+
+- **Standard install:** rerun `./install.sh` from a fresh clone of the `release/0.8.0` tag.
+- **Terraform install:** `terraform apply` against the updated module.
+- **DABS bundle (advanced):** `databricks bundle deploy` from the repo root.
+
+### What you'll notice after the upgrade
+
+<Admonition type="info" title="One-time consent re-prompt for the Permissions Analysis app">
+The Permissions Analysis (BrickHound) app now uses on-behalf-of-user (OBO) authentication so Unity Catalog enforces each caller's grants on the BrickHound tables. The required `sql` scope is set automatically by the SAT install. **Existing users who opened the app before the upgrade will see a friendly "missing sql scope" banner once** — until they trigger a fresh OAuth consent prompt by opening the app in a private/incognito window or clearing cookies for the workspace domain. New users hit no prompt because consent fires automatically on first open.
+
+Full setup on the [Permissions Analysis page](./functionality/permissions-analysis); workaround details in [Troubleshooting](./troubleshooting).
+</Admonition>
+
+<Admonition type="info" title="Dashboard check count goes up">
+0.8.0 adds new security checks across Data Protection, Governance, Identity & Access, Network Security, and Informational categories. Your dashboard rows will increase the first time the driver runs after the upgrade. Review the new findings against your security baseline — some may surface deviations that were previously not measured. You can disable any check via the `7. update_sat_check_configuration` notebook (see [Usage → Modifying Security Best Practices](./usage#modifying-security-best-practices)).
+</Admonition>
+
+<Admonition type="info" title="IA-9 no longer evaluated on Azure">
+**IA-9** ("Service principal client secrets not stale") is now evaluated on AWS and GCP only. Azure service principals are typically managed in Microsoft Entra ID and their OAuth credentials live there, not in Databricks — so the Databricks API does not return a representative view of secret rotation posture for Azure deployments. To avoid misleading "pass" results, the check is disabled at the configuration level for Azure. AWS and GCP behavior is unchanged.
+
+If you see fewer Identity & Access rows on Azure dashboards than before, this is the reason.
+</Admonition>
+
+<Admonition type="info" title="NS-14 reads 'egress blocked' as the pass state">
+**NS-14** is a new live behavior check. It runs from the SAT driver compute and probes a small set of public destinations to confirm whether outbound traffic actually escapes. On a network with restrictive egress controls, the probes are *expected* to fail — and that's the pass state. If your workspace is properly locked down and you see NS-14 reporting "egress blocked," no action is required.
+</Admonition>
+
+### Other upgrade notes
+
+- **SDK version**: SAT 0.8.0 ships `dbl_sat_sdk-0.1.51`. Re-deploy picks it up automatically; manual installs should reference the wheel under `lib/`.
+- **Serverless compute**: SAT jobs and the Permissions Analysis app pin to **Environment v5** for predictable behavior across DABS and Terraform installs.
+- **Secret scanner coverage**: cluster init scripts referenced via FUSE mount paths are now scanned alongside `spark_env_vars`. See [Cluster Secrets Scanning](./functionality/cluster-secrets-scanning).
+
+### If something looks wrong
+
+- Run the diagnosis notebook for your cloud (`notebooks/diagnosis/sat_diagnosis_<cloud>.py`) — see [Troubleshooting](./troubleshooting).
+- Check the [Troubleshooting](./troubleshooting) page for entries on the BrickHound consent banner, missing UC SELECT, and NS-14 expected behavior.
+- Open a [GitHub Issue](https://github.com/databricks-industry-solutions/security-analysis-tool/issues) if you hit something not covered.

--- a/docs/sat/sidebars.ts
+++ b/docs/sat/sidebars.ts
@@ -62,6 +62,7 @@ const sidebars = {
         },
       ],
     },
+    'upgrade',
     'usage',
     'faq',
     'troubleshooting',


### PR DESCRIPTION
## Summary

Pure-docs PR aligning the public site at https://databricks-industry-solutions.github.io/security-analysis-tool/ with what 0.8.0 actually ships. Two commits, ordered Tier 1 → Tier 2 from the planning doc.

### Tier 1 — accuracy fixes (the must-haves)

- **\`docs/sat/docs/functionality/index.mdx\`** — bump the "evaluates over 60" count to "65+" and add a one-line note that NS-14 (live egress testing) is new in 0.8.0; mention per-cloud applicability in the CSV.
- **\`docs/sat/docs/functionality/cluster-secrets-scanning.mdx\`** — expand "What It Does" to describe 0.8.0 coverage (cluster init scripts via FUSE mount paths, FILE-type secret detection, DetectorName field consistency) and note the TruffleHog tagged-release pin.
- **\`docs/sat/docs/troubleshooting.mdx\`** — three new AccordionItems for the post-upgrade failure modes admins are most likely to hit: Permissions Analysis consent re-prompt after upgrade, missing UC SELECT on the BrickHound tables, and NS-14 reading "egress blocked" as the pass state.
- **\`docs/sat/docs/upgrade.mdx\`** (new) — short upgrade guide explaining what 0.7.x users will see after upgrading to 0.8.0: re-deploy steps, the consent re-prompt, dashboard check-count delta, IA-9 no longer evaluated on Azure, NS-14 expected behavior on egress-restricted networks, the SDK version bump, and Environment v5 pinning.

### Tier 2 — adoption helpers

- **\`docs/sat/docs/functionality/index.mdx\`** — add a "What's new in 0.8.0" admonition with five headline bullets at the top, plus a "Live behavior tests" subsection explaining why NS-14 is qualitatively different from the rest of the checks.
- **\`README.md\`** — one-line "Latest version: v0.8.0" pointer near the top with a link to the upgrade guide, for drive-by GitHub visitors.

The Permissions Analysis page (\`docs/sat/docs/functionality/permissions-analysis.mdx\`) was already updated for OBO via PR #338 and needs no further work.

## Test plan

- [x] \`codespell\` clean across the diff (both commits).
- [x] CSV cross-check: 65 enabled rows in \`configs/security_best_practices.csv\` matches the count in the docs.
- [ ] Docusaurus local preview (\`cd docs/sat && npm install && npm run start\`) by a reviewer with Node available — confirms the new \`upgrade.mdx\` page renders, picks up sidebar position 4, and that the new admonition / subsection on \`functionality/index.mdx\` displays as expected.
- [ ] Eyeball the rendered upgrade page on the deploy preview after merge.

No code changes. No screenshot changes. Squash-merge into \`release/0.8.0\` so it rides the Thursday merge to \`main\`.

This pull request was AI-assisted by Isaac.