### PR TITLE
fix: deduplicate BrickHound vertices by id before write

### DIFF
--- a/notebooks/permission_analysis_data_collection.py
+++ b/notebooks/permission_analysis_data_collection.py
@@ -2937,6 +2937,24 @@ for v in all_vertices:
 for e in all_edges:
     e['run_id'] = RUN_ID
 
+# Deduplicate vertices by id before writing. A vertex id is unique per
+# entity within a run, so two rows sharing an id are the same entity and
+# keeping the first occurrence is lossless.
+_seen_vertex_ids = set()
+_deduped_vertices = []
+_dropped_dupes = 0
+for v in all_vertices:
+    vid = v['id']
+    if vid in _seen_vertex_ids:
+        _dropped_dupes += 1
+        continue
+    _seen_vertex_ids.add(vid)
+    _deduped_vertices.append(v)
+if _dropped_dupes:
+    print(f"   Deduplicated vertices: dropped {_dropped_dupes} duplicate id(s) "
+          f"({len(_deduped_vertices)} unique of {len(all_vertices)} collected)")
+all_vertices = _deduped_vertices
+
 # Create DataFrames
 print("\n Creating DataFrames...")
 vertices_df = spark.createDataFrame(all_vertices, schema=vertices_schema)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our versioning guidelines: https://github.com/databricks-industry-solutions/security-analysis-tool/blob/main/VERSIONING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
Post-collection validation fails the whole permissions-analysis run when duplicate vertex IDs are present. Collapse vertices to the first occurrence of each id before building the DataFrame so the uniqueness contract holds.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (non-code changes like README or docs)

## Checklist
- [x] I have reviewed the [CONTRIBUTING](https://github.com/databricks-industry-solutions/security-analysis-tool/blob/main/CONTRIBUTING.md) and [VERSIONING](https://github.com/databricks-industry-solutions/security-analysis-tool/blob/main/VERSIONING.md) documentation.
- [x] My code follows the code style of this project.
- [x] I have verified, added or updated the tests to cover my changes (if applicable).
- [x] I have verified that my changes do not introduce any breaking changes on all the supported clouds (AWS, Azure, GCP).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (if applicable).

## Screenshots (If Applicable)
<!-- Add before/after code changes, console output, etc. -->

## Additional Notes
<!--
Add any other relevant info here (e.g., deployment changes, new tests, breaking API changes, external dependencies).
-->