### PR TITLE
Perf/secrets scanner performance

### DIFF
--- a/configs/trufflehog_detectors.yaml
+++ b/configs/trufflehog_detectors.yaml
@@ -40,13 +40,20 @@ settings:
     json_output: true
     
   rate_limiting:
-    api_sleep_seconds: 10  # Sleep between API calls to prevent rate limiting
-    
+    api_sleep_seconds: 10  # Backoff base (seconds) used only when the API returns
+                           # HTTP 429. There is no unconditional inter-call sleep.
+
+  performance:
+    max_workers: 16  # Threads for I/O-bound work (workspace/list, get-status,
+                     # notebook export/FUSE copy). I/O-bound, so > core count is fine.
+
   file_paths:
     temp_config: "/tmp/trufflehog_config.yaml"
     temp_notebooks: "/tmp/notebooks"
     results_log: "/tmp/trufflehog_scan_results.json"
-    
+    scan_batch_dir: "/tmp/notebook_scan_batch"  # Dir where a chunk of notebooks is
+                                                # materialized for a single TruffleHog pass
+
   search_settings:
     page_size: 50
     days_back: 1  # Number of days back to search for modified notebooks

--- a/dabs/dabs_template/template/tmp/resources/sat_secrets_scanner_job.yml.tmpl
+++ b/dabs/dabs_template/template/tmp/resources/sat_secrets_scanner_job.yml.tmpl
@@ -2,6 +2,9 @@ resources:
   jobs:
     sat_secrets:
       name: "SAT Secrets Scanner"
+      # Upper bound for the whole run. Generous enough for large multi-workspace
+      # accounts, but fails fast instead of letting a stuck run hang indefinitely.
+      timeout_seconds: 28800  # 8 hours
       tags:
         Application: SAT
       schedule:

--- a/notebooks/Includes/scan_secrets/cluster_secrets_scan.py
+++ b/notebooks/Includes/scan_secrets/cluster_secrets_scan.py
@@ -166,6 +166,7 @@ import subprocess
 import time
 import hashlib
 import logging
+import concurrent.futures
 from typing import Dict, List, Any, Optional
 from datetime import datetime, timezone
 
@@ -211,6 +212,9 @@ class Config:
 
     # API settings
     API_SLEEP_SECONDS = 10  # Rate limiting between cluster API calls
+    # Concurrency: clusters are scanned in parallel (config fetch + TruffleHog
+    # scan are independent per cluster). DB inserts stay on the main thread.
+    MAX_WORKERS = 8
 
     # Scanning settings
     CONFIG_FIELD = "spark_env_vars"  # Which cluster config field to scan
@@ -755,6 +759,50 @@ print("✅ Database storage functions defined successfully!")
 
 # COMMAND ----------
 
+def _scan_one_cluster_for_secrets(cluster: Dict[str, Any]) -> Dict[str, Any]:
+    """Fetch a cluster's config and scan its env vars for secrets.
+
+    Pure worker: performs no DB writes, so it is safe to run in a thread pool.
+    Returns a result dict the main thread aggregates and persists. `scanned`
+    is True only when env vars were present and actually scanned (matching the
+    original loop's counting).
+    """
+    cluster_id = cluster.get('cluster_id')
+    cluster_name = cluster.get('cluster_name', 'Unknown')
+    result = {"cluster_id": cluster_id, "cluster_name": cluster_name, "scanned": False, "secrets": []}
+
+    try:
+        cluster_config = get_cluster_config(cluster_id)
+        if not cluster_config:
+            logger.warning(f"Failed to get config for cluster {cluster_id}, skipping")
+            return result
+
+        env_vars = extract_spark_env_vars(cluster_config)
+        if not env_vars:
+            logger.debug(f"No environment variables in cluster {cluster_name}, skipping")
+            return result
+
+        logger.info(f"Scanning {len(env_vars)} environment variables in cluster {cluster_name}")
+        file_path = serialize_env_vars_to_file(cluster_id, cluster_name, env_vars)
+        try:
+            built_in_results, custom_results = scan_cluster_config_for_secrets(file_path)
+            secrets_found = process_trufflehog_output(
+                built_in_results, custom_results, cluster_id, cluster_name, file_path
+            )
+        finally:
+            try:
+                os.remove(file_path)
+            except Exception:
+                pass
+
+        result["scanned"] = True
+        result["secrets"] = secrets_found or []
+        return result
+    except Exception as e:
+        logger.error(f"Error scanning cluster {cluster_id}: {str(e)}")
+        return result
+
+
 def main_cluster_scanning_workflow():
     """
     Main workflow for scanning cluster configurations for secrets.
@@ -782,53 +830,29 @@ def main_cluster_scanning_workflow():
 
         logger.info(f"📊 Found {total_clusters} clusters to scan")
 
-        # Scan each cluster
-        for idx, cluster in enumerate(clusters, 1):
-            cluster_id = cluster.get('cluster_id')
-            cluster_name = cluster.get('cluster_name', 'Unknown')
-
-            logger.info(f"[{idx}/{total_clusters}] Processing cluster: {cluster_name} ({cluster_id})")
-
-            try:
-                # Get full cluster configuration
-                cluster_config = get_cluster_config(cluster_id)
-
-                if not cluster_config:
-                    logger.warning(f"Failed to get config for cluster {cluster_id}, skipping")
+        # Scan clusters in parallel (config fetch + TruffleHog scan per cluster
+        # are independent). The previous version scanned serially with a fixed
+        # API_SLEEP_SECONDS pause between every cluster — that sleep is gone;
+        # DB inserts are kept on the main thread for Spark safety.
+        max_workers = min(Config.MAX_WORKERS, max(1, total_clusters))
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+            for res in pool.map(_scan_one_cluster_for_secrets, clusters):
+                if not res["scanned"]:
                     continue
-
-                # Extract spark_env_vars
-                env_vars = extract_spark_env_vars(cluster_config)
-
-                if not env_vars:
-                    logger.debug(f"No environment variables in cluster {cluster_name}, skipping")
-                    continue
-
-                logger.info(f"Scanning {len(env_vars)} environment variables in cluster {cluster_name}")
-
-                # Serialize to temp file
-                file_path = serialize_env_vars_to_file(cluster_id, cluster_name, env_vars)
-
-                # Run TruffleHog dual-scan
-                built_in_results, custom_results = scan_cluster_config_for_secrets(file_path)
-
-                # Process results
-                secrets_found = process_trufflehog_output(
-                    built_in_results, custom_results, cluster_id, cluster_name, file_path
-                )
 
                 clusters_scanned += 1
+                secrets_found = res["secrets"]
 
                 if secrets_found:
                     clusters_with_secrets += 1
                     total_secrets_found += len(secrets_found)
 
-                    print(f"  🚨 SECRETS DETECTED in {cluster_name}: {len(secrets_found)} secrets found")
+                    print(f"  🚨 SECRETS DETECTED in {res['cluster_name']}: {len(secrets_found)} secrets found")
 
-                    # Store in database
+                    # Store in database (main thread)
                     cluster_metadata = {
-                        "cluster_id": cluster_id,
-                        "cluster_name": cluster_name,
+                        "cluster_id": res["cluster_id"],
+                        "cluster_name": res["cluster_name"],
                         "config_field": Config.CONFIG_FIELD,
                         "secrets_found": len(secrets_found),
                         "secret_details": secrets_found
@@ -836,24 +860,10 @@ def main_cluster_scanning_workflow():
 
                     try:
                         insert_cluster_secret_scan_results(workspace_id, cluster_metadata, current_run_id)
-                        logger.info(f"Stored {len(secrets_found)} secrets for cluster {cluster_id}")
+                        logger.info(f"Stored {len(secrets_found)} secrets for cluster {res['cluster_id']}")
                     except Exception as insert_error:
-                        logger.error(f"Database insertion failed for cluster {cluster_id}: {str(insert_error)}")
+                        logger.error(f"Database insertion failed for cluster {res['cluster_id']}: {str(insert_error)}")
                         print(f"  ❌ Database insertion failed: {str(insert_error)}")
-
-                # Clean up temp file
-                try:
-                    os.remove(file_path)
-                except:
-                    pass
-
-                # Rate limiting
-                if idx < total_clusters:
-                    time.sleep(Config.API_SLEEP_SECONDS)
-
-            except Exception as e:
-                logger.error(f"Error scanning cluster {cluster_id}: {str(e)}")
-                continue
 
         # Insert tracking row if no secrets found anywhere
         if total_secrets_found == 0:

--- a/notebooks/Includes/scan_secrets/notebook_secret_scan.py
+++ b/notebooks/Includes/scan_secrets/notebook_secret_scan.py
@@ -175,6 +175,7 @@ import hashlib
 import logging
 import shutil
 import yaml
+import concurrent.futures
 from datetime import timedelta, datetime
 from urllib.parse import quote
 from typing import Dict, List, Optional, Any, Tuple
@@ -252,7 +253,15 @@ class Config:
     
     # TruffleHog settings from config
     EXCLUDED_DETECTORS = config_data.get("settings", {}).get("excluded_detectors", ["DatabricksToken"])
-    
+
+    # Concurrency: number of threads for I/O-bound work (workspace/list,
+    # get-status, notebook export/FUSE copy). I/O-bound, so a pool well above
+    # the core count is fine.
+    MAX_WORKERS = config_data.get("settings", {}).get("performance", {}).get("max_workers", 16)
+    # Directory where a batch of notebooks is materialized so TruffleHog can
+    # scan them all in a single invocation instead of once per file.
+    SCAN_BATCH_DIR = config_data.get("settings", {}).get("file_paths", {}).get("scan_batch_dir", "/tmp/notebook_scan_batch")
+
 # Extract Databricks authentication context
 # These are automatically available in Databricks notebooks
 try:
@@ -358,26 +367,38 @@ def make_api_request(url: str, headers: Dict[str, str], data: Optional[Dict[str,
     Returns a (json_or_none, status_or_none) tuple so callers can branch
     on HTTP status. Status is None when the request never reached the
     server (timeout / connection error).
+
+    Rate limits (429) are retried internally with exponential backoff so a
+    transient throttle no longer aborts pagination. We only sleep when the
+    API actually throttles us — there is no unconditional inter-call sleep.
     """
-    try:
-        response = requests.get(url, headers=headers, json=data, timeout=30)
+    max_attempts = 5
+    for attempt in range(max_attempts):
+        try:
+            response = requests.get(url, headers=headers, json=data, timeout=30)
 
-        if response.status_code == 200:
-            return response.json(), 200
-        elif response.status_code == 429:
-            logger.warning(f"Rate limit hit for URL: {url}. Waiting before retry...")
-            time.sleep(Config.API_SLEEP_SECONDS * 2)  # Wait longer for rate limits
-            return None, 429
-        else:
-            logger.warning(f"API request failed. URL: {url}, Status: {response.status_code}")
-            return None, response.status_code
+            if response.status_code == 200:
+                return response.json(), 200
+            elif response.status_code == 429:
+                if attempt == max_attempts - 1:
+                    logger.warning(f"Rate limit persisted after {max_attempts} attempts for URL: {url}")
+                    return None, 429
+                backoff = Config.API_SLEEP_SECONDS * (2 ** attempt)
+                logger.warning(f"Rate limit hit for URL: {url}. Backing off {backoff}s (attempt {attempt + 1}/{max_attempts})")
+                time.sleep(backoff)
+                continue
+            else:
+                logger.warning(f"API request failed. URL: {url}, Status: {response.status_code}")
+                return None, response.status_code
 
-    except requests.exceptions.Timeout:
-        logger.error(f"Request timeout for URL: {url}")
-        return None, None
-    except requests.exceptions.RequestException as e:
-        logger.error(f"Request error for URL: {url}. Error: {str(e)}")
-        return None, None
+        except requests.exceptions.Timeout:
+            logger.error(f"Request timeout for URL: {url}")
+            return None, None
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Request error for URL: {url}. Error: {str(e)}")
+            return None, None
+
+    return None, 429
 
 def check_notebook_status(notebook_path: str) -> int:
     """
@@ -418,68 +439,82 @@ def _get_object_metadata(path: str) -> Optional[Dict[str, Any]]:
         return None
 
 
-def _list_workspace_recursive(path: str,
-                              results: List[Dict[str, Any]],
-                              cutoff_ms: Optional[int] = None) -> None:
-    """Recursively enumerate NOTEBOOK / FILE objects under `path`.
+def _list_dir(path: str) -> List[Dict[str, Any]]:
+    """Single /workspace/list call. Returns the raw objects list (empty on error/404).
 
-    Appends entries to `results` in the shape `_process_notebook_batch`
-    expects: {id, name, workspace_path}. If `cutoff_ms` is provided,
-    only objects with `modified_at >= cutoff_ms` are included (one
-    extra /workspace/get-status call per leaf).
+    404 is normal for tree roots that don't exist on every workspace
+    (e.g. /Repos on workspaces without Git integration).
     """
     url = f"{base_url}/api/2.0/workspace/list?path={quote(path)}"
     headers = {"Authorization": f"Bearer {token}", "User-Agent": "databricks-sat/0.1.0"}
     try:
         r = requests.get(url, headers=headers, timeout=30)
         if r.status_code != 200:
-            # 404 is normal for tree roots that don't exist on every
-            # workspace (e.g. /Repos on workspaces without Git integration).
             if r.status_code != 404:
                 logger.warning(f"workspace/list returned {r.status_code} for {path}")
-            return
-        objs = r.json().get("objects", [])
+            return []
+        return r.json().get("objects", [])
     except requests.exceptions.RequestException as e:
         logger.warning(f"workspace/list failed for {path}: {str(e)}")
-        return
-
-    for obj in objs:
-        obj_type = obj.get("object_type")
-        obj_path = obj.get("path", "")
-        if not obj_path:
-            continue
-
-        if obj_type in ("DIRECTORY", "REPO"):
-            _list_workspace_recursive(obj_path, results, cutoff_ms)
-        elif obj_type in ("NOTEBOOK", "FILE"):
-            if cutoff_ms is not None:
-                meta = _get_object_metadata(obj_path)
-                if not meta:
-                    continue
-                modified_at = meta.get("modified_at", 0)
-                if modified_at < cutoff_ms:
-                    continue
-            results.append({
-                "id": str(obj.get("object_id", "")),
-                "name": obj_path.rsplit("/", 1)[-1],
-                "workspace_path": obj_path.rsplit("/", 1)[0],
-            })
+        return []
 
 
 def discover_notebooks_via_workspace_list(time_filter_enabled: bool,
                                           last_edited_after: Optional[int]) -> List[Dict[str, Any]]:
-    """Fallback notebook discovery using /workspace/list + /get-status.
+    """Fallback notebook discovery using /workspace/list (+ /get-status only when needed).
 
     Used when /search-midtier/unified-search rejects token-based auth
     (returns 403). See GitHub issue #330 for context. The standard
-    discoverable trees — /Users, /Shared, /Repos — cover the common
-    cases; missing roots are tolerated silently (404).
+    discoverable trees — /Users, /Shared, /Repos — cover the common cases;
+    missing roots are tolerated silently (404).
+
+    Performance: directory traversal is fanned out across a thread pool one
+    level at a time instead of recursing serially, and the per-leaf
+    /workspace/get-status call is skipped entirely when the list response
+    already carries `modified_at`. get-status is only issued (and then in
+    parallel) for the leaves that lack it — eliminating the O(notebooks)
+    serial round-trips that made this path time out on large workspaces.
     """
     cutoff_ms = last_edited_after if time_filter_enabled else None
-    results: List[Dict[str, Any]] = []
-    for root in ("/Users", "/Shared", "/Repos"):
-        _list_workspace_recursive(root, results, cutoff_ms)
-    return results
+
+    # Phase 1: parallel breadth-first directory traversal.
+    leaves: List[Dict[str, Any]] = []
+    pending: List[str] = ["/Users", "/Shared", "/Repos"]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=Config.MAX_WORKERS) as pool:
+        while pending:
+            next_dirs: List[str] = []
+            for objs in pool.map(_list_dir, pending):
+                for obj in objs:
+                    obj_type = obj.get("object_type")
+                    if not obj.get("path"):
+                        continue
+                    if obj_type in ("DIRECTORY", "REPO"):
+                        next_dirs.append(obj["path"])
+                    elif obj_type in ("NOTEBOOK", "FILE"):
+                        leaves.append(obj)
+            pending = next_dirs
+
+    # Phase 2: time-window filter (only when enabled).
+    if cutoff_ms is None:
+        kept = leaves
+    else:
+        kept = [o for o in leaves if "modified_at" in o and o.get("modified_at", 0) >= cutoff_ms]
+        need_meta = [o for o in leaves if "modified_at" not in o]
+        if need_meta:
+            def _keep_if_recent(obj: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+                meta = _get_object_metadata(obj.get("path", ""))
+                if meta and meta.get("modified_at", 0) >= cutoff_ms:
+                    return obj
+                return None
+            with concurrent.futures.ThreadPoolExecutor(max_workers=Config.MAX_WORKERS) as pool:
+                kept.extend(o for o in pool.map(_keep_if_recent, need_meta) if o is not None)
+
+    # Normalize to the {id, name, workspace_path} shape the batch processor expects.
+    return [{
+        "id": str(obj.get("object_id", "")),
+        "name": obj.get("path", "").rsplit("/", 1)[-1],
+        "workspace_path": obj.get("path", "").rsplit("/", 1)[0],
+    } for obj in kept]
 
 def get_fuse_path(workspace_path: str) -> Optional[str]:
     """Find the actual file on the FUSE mount by trying common extensions."""
@@ -900,6 +935,127 @@ def scan_notebook_for_secrets(notebook_path: str, object_id: str) -> Optional[Li
         logger.error(f"Error scanning notebook {notebook_path}: {str(e)}")
         return None
 
+def _materialize_notebook(notebook: Dict[str, Any], scan_dir: str) -> Optional[Tuple[str, Dict[str, Any]]]:
+    """Write one notebook's content into `scan_dir` so a whole batch can be
+    scanned by TruffleHog in a single invocation.
+
+    The on-disk filename is the notebook's object_id, which lets findings be
+    mapped back to the notebook by source-file basename after the scan.
+    Mirrors the original FUSE-first / API-export fallback. Returns
+    (scan_file_path, metadata) on success, or None if the notebook could not
+    be materialized (missing fields, no access, export failure).
+    """
+    notebook_id = notebook.get("id", "")
+    notebook_name = notebook.get("name", "")
+    parent_path = notebook.get("workspace_path", "")
+
+    if not notebook_id or not notebook_name:
+        logger.warning("Skipping notebook with missing ID or name")
+        return None
+    if os.sep in str(notebook_id):
+        logger.warning(f"Skipping notebook with unsafe id: {notebook_id}")
+        return None
+
+    temp_path = f"{parent_path}/{notebook_name}"
+    path = quote(temp_path)
+    metadata = {"object_id": notebook_id, "path": path, "name": notebook_name}
+    scan_file = os.path.join(scan_dir, str(notebook_id))
+
+    try:
+        # Try FUSE mount first (fast local copy), fall back to API export.
+        fuse_path = get_fuse_path(path)
+        if fuse_path:
+            try:
+                shutil.copy2(fuse_path, scan_file)
+                return scan_file, metadata
+            except Exception as e:
+                logger.warning(f"FUSE copy failed for {fuse_path}, falling back to API: {e}")
+
+        notebook_status = check_notebook_status(path)
+        if notebook_status == 200:
+            export_response = export_notebook_content(path)
+            if not export_response:
+                logger.warning(f"Failed to export notebook content: {temp_path}")
+                return None
+            content = export_response.get("content")
+            if not content:
+                logger.warning(f"No content found in notebook: {temp_path}")
+                return None
+            if not decode_and_write_content(content, scan_file):
+                logger.error(f"Failed to write notebook content to file: {scan_file}")
+                return None
+            return scan_file, metadata
+        elif notebook_status == 403:
+            logger.warning(f"Access denied for notebook: {temp_path}")
+        elif notebook_status == 404:
+            logger.warning(f"Notebook not found: {temp_path}")
+        else:
+            logger.warning(f"Unexpected status {notebook_status} for notebook: {temp_path}")
+        return None
+    except Exception as e:
+        logger.error(f"Error materializing notebook {temp_path}: {str(e)}")
+        return None
+
+
+def _scan_and_record_chunk(chunk: List[Dict[str, Any]],
+                           results_list: List[Dict[str, Any]],
+                           output_filename: Optional[str],
+                           run_id: Optional[int],
+                           workspace_id: Optional[str]) -> None:
+    """Materialize a chunk of notebooks in parallel, scan the whole chunk with
+    a single TruffleHog pass, then attribute findings back to each notebook."""
+    scan_dir = Config.SCAN_BATCH_DIR
+    shutil.rmtree(scan_dir, ignore_errors=True)
+    os.makedirs(scan_dir, exist_ok=True)
+
+    # Phase 1: materialize notebook contents in parallel (I/O-bound).
+    basename_to_meta: Dict[str, Dict[str, Any]] = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=Config.MAX_WORKERS) as pool:
+        for res in pool.map(lambda nb: _materialize_notebook(nb, scan_dir), chunk):
+            if res is None:
+                continue
+            scan_file, metadata = res
+            basename_to_meta[os.path.basename(scan_file)] = metadata
+
+    # Record metadata + log line for every materialized notebook.
+    for metadata in basename_to_meta.values():
+        results_list.append(metadata)
+        if output_filename:
+            try:
+                with open(output_filename, mode="a", encoding="utf-8") as output_file:
+                    json.dump(metadata, output_file)
+                    output_file.write("\n")
+            except IOError as e:
+                logger.error(f"Failed to write to output file {output_filename}: {str(e)}")
+
+    if not basename_to_meta:
+        return
+
+    # Phase 2: a single TruffleHog pass over the whole chunk directory
+    # (built-in + custom detectors), instead of two subprocesses per file.
+    trufflehog_output = scan_for_secrets(scan_dir)
+    findings = process_trufflehog_output(trufflehog_output) if trufflehog_output else []
+
+    # Phase 3: attribute findings back to notebooks by source-file basename.
+    findings_by_notebook: Dict[str, List[Dict[str, str]]] = {}
+    for finding in findings:
+        key = os.path.basename(finding.get("SourceFile", ""))
+        findings_by_notebook.setdefault(key, []).append(finding)
+
+    # Phase 4: set counts, surface alerts, persist.
+    for key, metadata in basename_to_meta.items():
+        secret_results = findings_by_notebook.get(key, [])
+        if secret_results:
+            metadata["secrets_found"] = len(secret_results)
+            metadata["secret_details"] = secret_results
+            print(f"🚨 SECRETS DETECTED in {metadata['path']}:")
+            print(json.dumps(secret_results, indent=2))
+        else:
+            metadata["secrets_found"] = 0
+        if run_id is not None and workspace_id is not None:
+            insert_secret_scan_results(workspace_id, metadata, run_id)
+
+
 def _process_notebook_batch(batch: List[Dict[str, Any]],
                             results_list: List[Dict[str, Any]],
                             output_filename: Optional[str] = None,
@@ -911,57 +1067,18 @@ def _process_notebook_batch(batch: List[Dict[str, Any]],
     unified-search returns natively. The workspace/list fallback
     synthesizes the same shape so both discovery paths share this
     downstream processor (TruffleHog scan, DB insert, log file write).
+
+    Notebooks are processed in bounded chunks: each chunk is materialized in
+    parallel and scanned with a single TruffleHog invocation. This replaces
+    the previous per-notebook loop that spawned two subprocesses per file and
+    exported notebooks one at a time — the dominant cost on large workspaces.
     """
     logger.info(f"Processing {len(batch)} notebooks from discovery batch")
 
-    for notebook in batch:
-        notebook_id = notebook.get("id", "")
-        notebook_name = notebook.get("name", "")
-        parent_path = notebook.get("workspace_path", "")
-
-        if not notebook_id or not notebook_name:
-            logger.warning("Skipping notebook with missing ID or name")
-            continue
-
-        # Construct full notebook path
-        temp_path = f"{parent_path}/{notebook_name}"
-        path = quote(temp_path)
-
-        logger.info(f"Processing notebook: {notebook_id} - {temp_path}")
-
-        # Store notebook metadata
-        notebook_metadata = {"object_id": notebook_id, "path": path, "name": notebook_name}
-        results_list.append(notebook_metadata)
-
-        # Log to file if specified
-        if output_filename:
-            try:
-                with open(output_filename, mode="a", encoding="utf-8") as output_file:
-                    json.dump(notebook_metadata, output_file)
-                    output_file.write("\n")
-            except IOError as e:
-                logger.error(f"Failed to write to output file {output_filename}: {str(e)}")
-
-        # Scan notebook for secrets
-        secret_results = scan_notebook_for_secrets(path, notebook_id)
-
-        if secret_results:
-            # Store results with notebook metadata
-            notebook_metadata["secrets_found"] = len(secret_results)
-            notebook_metadata["secret_details"] = secret_results
-
-            # Log summary - only show when secrets are found
-            print(f"🚨 SECRETS DETECTED in {temp_path}:")
-            print(json.dumps(secret_results, indent=2))
-        else:
-            notebook_metadata["secrets_found"] = 0
-            # Don't print "No secrets found" to avoid overwhelming output with thousands of notebooks
-
-        # Store results in database if run_id and workspace_id are provided
-        logger.info(f"Inserting secret scan results for workspace_id: {workspace_id} and run_id: {run_id}")
-        logger.info(f"Notebook metadata: {json.dumps(notebook_metadata, indent=2)}")
-        if run_id is not None and workspace_id is not None:
-            insert_secret_scan_results(workspace_id, notebook_metadata, run_id)
+    chunk_size = max(1, Config.MAX_WORKERS * 8)
+    for start in range(0, len(batch), chunk_size):
+        _scan_and_record_chunk(batch[start:start + chunk_size],
+                               results_list, output_filename, run_id, workspace_id)
 
 
 def process_search_response(response: Dict[str, Any], results_list: List[Dict[str, Any]],
@@ -1144,12 +1261,11 @@ def main_scanning_workflow():
             print()
             
             page_number += 1
-            
-            # Rate limiting - sleep between API calls
-            if next_page_token is not None:
-                logger.info(f"Sleeping for {Config.API_SLEEP_SECONDS} seconds to prevent rate limiting...")
-                time.sleep(Config.API_SLEEP_SECONDS)
-        
+
+            # No unconditional inter-page sleep. Rate limiting is handled
+            # reactively inside make_api_request(), which backs off and
+            # retries only when the API actually returns HTTP 429.
+
         # Final summary
         print("🎉 Secret Scanning Completed!")
         print("=" * 60)

--- a/notebooks/Includes/scan_secrets/notebook_secret_scan.py
+++ b/notebooks/Includes/scan_secrets/notebook_secret_scan.py
@@ -175,6 +175,7 @@ import hashlib
 import logging
 import shutil
 import yaml
+import tempfile
 import concurrent.futures
 from datetime import timedelta, datetime
 from urllib.parse import quote
@@ -1003,57 +1004,64 @@ def _scan_and_record_chunk(chunk: List[Dict[str, Any]],
                            run_id: Optional[int],
                            workspace_id: Optional[str]) -> None:
     """Materialize a chunk of notebooks in parallel, scan the whole chunk with
-    a single TruffleHog pass, then attribute findings back to each notebook."""
-    scan_dir = Config.SCAN_BATCH_DIR
-    shutil.rmtree(scan_dir, ignore_errors=True)
-    os.makedirs(scan_dir, exist_ok=True)
+    a single TruffleHog pass, then attribute findings back to each notebook.
 
-    # Phase 1: materialize notebook contents in parallel (I/O-bound).
-    basename_to_meta: Dict[str, Dict[str, Any]] = {}
-    with concurrent.futures.ThreadPoolExecutor(max_workers=Config.MAX_WORKERS) as pool:
-        for res in pool.map(lambda nb: _materialize_notebook(nb, scan_dir), chunk):
-            if res is None:
-                continue
-            scan_file, metadata = res
-            basename_to_meta[os.path.basename(scan_file)] = metadata
+    Uses a fresh, unique temp directory per chunk (tempfile.mkdtemp). This is
+    required for correctness: when multiple workspaces are scanned concurrently,
+    every child notebook shares the same driver-local filesystem, so a fixed
+    shared directory would let one scan's files clobber another's.
+    """
+    os.makedirs(Config.SCAN_BATCH_DIR, exist_ok=True)
+    scan_dir = tempfile.mkdtemp(dir=Config.SCAN_BATCH_DIR)
+    try:
+        # Phase 1: materialize notebook contents in parallel (I/O-bound).
+        basename_to_meta: Dict[str, Dict[str, Any]] = {}
+        with concurrent.futures.ThreadPoolExecutor(max_workers=Config.MAX_WORKERS) as pool:
+            for res in pool.map(lambda nb: _materialize_notebook(nb, scan_dir), chunk):
+                if res is None:
+                    continue
+                scan_file, metadata = res
+                basename_to_meta[os.path.basename(scan_file)] = metadata
 
-    # Record metadata + log line for every materialized notebook.
-    for metadata in basename_to_meta.values():
-        results_list.append(metadata)
-        if output_filename:
-            try:
-                with open(output_filename, mode="a", encoding="utf-8") as output_file:
-                    json.dump(metadata, output_file)
-                    output_file.write("\n")
-            except IOError as e:
-                logger.error(f"Failed to write to output file {output_filename}: {str(e)}")
+        # Record metadata + log line for every materialized notebook.
+        for metadata in basename_to_meta.values():
+            results_list.append(metadata)
+            if output_filename:
+                try:
+                    with open(output_filename, mode="a", encoding="utf-8") as output_file:
+                        json.dump(metadata, output_file)
+                        output_file.write("\n")
+                except IOError as e:
+                    logger.error(f"Failed to write to output file {output_filename}: {str(e)}")
 
-    if not basename_to_meta:
-        return
+        if not basename_to_meta:
+            return
 
-    # Phase 2: a single TruffleHog pass over the whole chunk directory
-    # (built-in + custom detectors), instead of two subprocesses per file.
-    trufflehog_output = scan_for_secrets(scan_dir)
-    findings = process_trufflehog_output(trufflehog_output) if trufflehog_output else []
+        # Phase 2: a single TruffleHog pass over the whole chunk directory
+        # (built-in + custom detectors), instead of two subprocesses per file.
+        trufflehog_output = scan_for_secrets(scan_dir)
+        findings = process_trufflehog_output(trufflehog_output) if trufflehog_output else []
 
-    # Phase 3: attribute findings back to notebooks by source-file basename.
-    findings_by_notebook: Dict[str, List[Dict[str, str]]] = {}
-    for finding in findings:
-        key = os.path.basename(finding.get("SourceFile", ""))
-        findings_by_notebook.setdefault(key, []).append(finding)
+        # Phase 3: attribute findings back to notebooks by source-file basename.
+        findings_by_notebook: Dict[str, List[Dict[str, str]]] = {}
+        for finding in findings:
+            key = os.path.basename(finding.get("SourceFile", ""))
+            findings_by_notebook.setdefault(key, []).append(finding)
 
-    # Phase 4: set counts, surface alerts, persist.
-    for key, metadata in basename_to_meta.items():
-        secret_results = findings_by_notebook.get(key, [])
-        if secret_results:
-            metadata["secrets_found"] = len(secret_results)
-            metadata["secret_details"] = secret_results
-            print(f"🚨 SECRETS DETECTED in {metadata['path']}:")
-            print(json.dumps(secret_results, indent=2))
-        else:
-            metadata["secrets_found"] = 0
-        if run_id is not None and workspace_id is not None:
-            insert_secret_scan_results(workspace_id, metadata, run_id)
+        # Phase 4: set counts, surface alerts, persist.
+        for key, metadata in basename_to_meta.items():
+            secret_results = findings_by_notebook.get(key, [])
+            if secret_results:
+                metadata["secrets_found"] = len(secret_results)
+                metadata["secret_details"] = secret_results
+                print(f"🚨 SECRETS DETECTED in {metadata['path']}:")
+                print(json.dumps(secret_results, indent=2))
+            else:
+                metadata["secrets_found"] = 0
+            if run_id is not None and workspace_id is not None:
+                insert_secret_scan_results(workspace_id, metadata, run_id)
+    finally:
+        shutil.rmtree(scan_dir, ignore_errors=True)
 
 
 def _process_notebook_batch(batch: List[Dict[str, Any]],

--- a/notebooks/security_analysis_secrets_scanner.py
+++ b/notebooks/security_analysis_secrets_scanner.py
@@ -150,7 +150,7 @@ def processTruffleHogScan(wsrow, run_id):
     loggr.info(f"Running TruffleHog notebook scan for workspace: {workspace_id}")
     scan_result = dbutils.notebook.run(
         f"{basePath()}/notebooks/Includes/scan_secrets/notebook_secret_scan",
-        3600,  # 1 hour timeout for secrets scanning
+        14400,  # 4 hour timeout for secrets scanning
         {"json_": json.dumps(ws_json)},
     )
     loggr.info(f"Notebook scan completed for workspace: {workspace_id}")
@@ -192,7 +192,7 @@ def processClusterScan(wsrow, run_id):
     loggr.info(f"Running cluster config scan for workspace: {workspace_id}")
     scan_result = dbutils.notebook.run(
         f"{basePath()}/notebooks/Includes/scan_secrets/cluster_secrets_scan",
-        3600,  # 1 hour timeout for cluster scanning
+        14400,  # 4 hour timeout for cluster scanning
         {"json_": json.dumps(ws_json)},
     )
     loggr.info(f"Cluster scan completed for workspace: {workspace_id}")
@@ -203,7 +203,14 @@ def runTruffleHogScanForAllWorkspaces():
     """
     Run secret scanning (notebooks + clusters) for all configured workspaces.
     Each workspace gets a shared run_id for correlation between notebook and cluster findings.
+
+    Workspaces are scanned concurrently, and within each workspace the notebook
+    and cluster scans run concurrently. Degree of cross-workspace parallelism is
+    controlled by `secrets_max_parallel_workspaces` (default 4). A scan failure
+    in one workspace is logged and does not stop the others.
     """
+    import concurrent.futures
+
     loggr.info("Starting secret scanning for all configured workspaces")
 
     scan_workspaces = workspaces
@@ -214,42 +221,53 @@ def runTruffleHogScanForAllWorkspaces():
 
     loggr.info(f"Running secret scans on {len(scan_workspaces)} workspace(s)")
 
-    # Run secret scanning (sequential for now to avoid overwhelming the system)
-    for ws in scan_workspaces:
-        try:
-            # Generate shared run_id for this workspace
-            shared_run_id = generate_shared_run_id()
-            loggr.info(f"Starting scans for workspace: {ws.workspace_id} (run_id: {shared_run_id})")
-            print(f"🔍 Starting scans for workspace: {ws.workspace_id} (run_id: {shared_run_id})")
+    # Pre-allocate a shared run_id per workspace sequentially on the main thread.
+    # generate_shared_run_id() does INSERT + SELECT max(runID), which would race
+    # under concurrency (two workspaces could read the same max), so it must run
+    # before the parallel fan-out.
+    ws_run_ids = [(ws, generate_shared_run_id()) for ws in scan_workspaces]
 
-            # Scan notebooks
+    def scan_one_workspace(ws, shared_run_id):
+        loggr.info(f"Starting scans for workspace: {ws.workspace_id} (run_id: {shared_run_id})")
+        print(f"🔍 Starting scans for workspace: {ws.workspace_id} (run_id: {shared_run_id})")
+
+        def notebook_scan():
             try:
-                loggr.info(f"Starting notebook scan for workspace: {ws.workspace_id}")
-                notebook_result = processTruffleHogScan(ws, shared_run_id)
+                processTruffleHogScan(ws, shared_run_id)
                 loggr.info(f"Notebook scan completed for workspace: {ws.workspace_id}")
-                print(f"  ✅ Notebook scan completed")
+                print(f"  ✅ Notebook scan completed for {ws.workspace_id}")
             except Exception as e:
                 loggr.error(f"Notebook scan failed for workspace {ws.workspace_id}: {str(e)}")
-                print(f"  ❌ Notebook scan failed: {str(e)}")
-                # Continue to cluster scan even if notebook scan fails
+                print(f"  ❌ Notebook scan failed for {ws.workspace_id}: {str(e)}")
 
-            # Scan clusters
+        def cluster_scan():
             try:
-                loggr.info(f"Starting cluster scan for workspace: {ws.workspace_id}")
-                cluster_result = processClusterScan(ws, shared_run_id)
+                processClusterScan(ws, shared_run_id)
                 loggr.info(f"Cluster scan completed for workspace: {ws.workspace_id}")
-                print(f"  ✅ Cluster scan completed")
+                print(f"  ✅ Cluster scan completed for {ws.workspace_id}")
             except Exception as e:
                 loggr.error(f"Cluster scan failed for workspace {ws.workspace_id}: {str(e)}")
-                print(f"  ❌ Cluster scan failed: {str(e)}")
-                # Continue to next workspace
+                print(f"  ❌ Cluster scan failed for {ws.workspace_id}: {str(e)}")
 
-            print(f"✅ All scans completed for workspace: {ws.workspace_id}")
+        # Notebook and cluster scans are independent — run them concurrently.
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as inner:
+            for f in [inner.submit(notebook_scan), inner.submit(cluster_scan)]:
+                f.result()
+        print(f"✅ All scans completed for workspace: {ws.workspace_id}")
 
-        except Exception as e:
-            loggr.error(f"Fatal error scanning workspace {ws.workspace_id}: {str(e)}")
-            print(f"❌ Fatal error for workspace: {ws.workspace_id}")
-            continue
+    max_parallel = max(1, int(json_.get("secrets_max_parallel_workspaces", 4)))
+    max_parallel = min(max_parallel, len(ws_run_ids))
+    loggr.info(f"Scanning up to {max_parallel} workspace(s) in parallel")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_parallel) as pool:
+        futures = {pool.submit(scan_one_workspace, ws, rid): ws for ws, rid in ws_run_ids}
+        for f in concurrent.futures.as_completed(futures):
+            ws = futures[f]
+            try:
+                f.result()
+            except Exception as e:
+                loggr.error(f"Fatal error scanning workspace {ws.workspace_id}: {str(e)}")
+                print(f"❌ Fatal error for workspace: {ws.workspace_id}: {str(e)}")
 
 
 runTruffleHogScanForAllWorkspaces()

--- a/terraform/common/jobs.tf
+++ b/terraform/common/jobs.tf
@@ -129,6 +129,9 @@ resource "databricks_job" "driver" {
 
 resource "databricks_job" "secrets_scanner" {
   name = "SAT Secrets Scanner"
+  # Upper bound for the whole run. Generous enough for large multi-workspace
+  # accounts, but fails fast instead of letting a stuck run hang indefinitely.
+  timeout_seconds = 28800 # 8 hours
   tags = {
     Application = "SAT"
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our versioning guidelines: https://github.com/databricks-industry-solutions/security-analysis-tool/blob/main/VERSIONING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
The scanner now batches TruffleHog over a chunk of notebooks (one pass instead of two subprocesses per file), parallelizes notebook/cluster I/O and scans workspaces concurrently, drops the fixed 10s inter-page/per-cluster sleeps for 429-only backoff, and skips the per-notebook get-status in the 403 fallback. Also raises the inner timeout to 4h and adds an 8h job timeout.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (non-code changes like README or docs)
