### PR TITLE
feat(secrets): support BYO secret scope and direct config params

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,13 @@ uniqueness, URL, and typo checks.
   `SatDBClient._update_token_master()` (AWS/GCP OAuth, Azure MSAL + Databricks).
 - Use the centralized logger (`LoggingUtils`) in SDK code; escape single quotes
   in any JSON before building SQL `INSERT` statements.
+- **Secret key names are indirected** through `DEFAULT_SECRET_KEYS` in
+  `notebooks/Utils/common.py` and the `secret_key_names` override map. Never
+  hardcode key string literals (e.g. `"client-secret"`, `"account-console-id"`)
+  directly in notebook cells or SDK code — always resolve through
+  `SECRET_KEYS[logical_name]` or the `read_sat_secret()` / `resolve_sat_value()`
+  helpers. Only `client_secret` must live in the scope; all other values travel
+  as job `base_parameters` with scope fallback.
 
 ## When you finish
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -600,7 +600,7 @@ This ensures users have complete visibility into what changes were made and whet
 
 ## Important Implementation Details
 
-1. **Secret Storage:** All credentials stored in Databricks secret scope `sat_scope` during DABS installation
+1. **Secret Storage:** Only `client_secret` (SP OAuth secret) and the dormant PAT prefix must live in the secret scope. The scope name is configurable (`secret_scope_name` in Terraform; `secret_scope` prompt in DABS); default `sat_scope`. All other values — Account ID, Client ID, SQL Warehouse ID, `analysis_schema_name`, proxies, etc. — are passed as direct job `base_parameters` in 0.9+ installs, with the scope as a fallback so 0.8.x scopes continue to work unchanged.
 2. **Workspace filtering:** Use `serverless_filter` SQL clause when running on serverless
 3. **Pagination:** Controlled by `maxpages` and `timebetweencalls` config parameters
 4. **Token refresh:** Tokens regenerated per API call in `_update_token_master()` based on endpoint routing
@@ -616,7 +616,7 @@ BrickHound provides graph-based permissions analysis within SAT, complementing S
 ### Location and Structure
 
 **Notebooks**: `/notebooks/brickhound/`
-- `00_config.py` - Configuration (reads from sat_scope)
+- `00_config.py` - Configuration (reads `analysis_schema_name` from `json_`, which was set by `initialize.py` via param→scope resolution)
 - `00_analysis_common.py` - Shared utilities
 - `01_data_collection.py` - Main collector (2694 lines)
 - `02-05_*.py` - Interactive analysis notebooks
@@ -636,11 +636,11 @@ BrickHound provides graph-based permissions analysis within SAT, complementing S
 
 ### Architecture
 
-**Credentials**: Uses SAT's `sat_scope` secret scope
-- `account-console-id` → Account UUID
-- `client-id` → Service Principal Application ID  
-- `client-secret` → Service Principal OAuth Secret
-- `analysis_schema_name` → Unity Catalog schema (catalog.schema format)
+**Credentials**: Uses the configured SAT secret scope (default `sat_scope`; configurable via `secret_scope_name` / `secret_scope` prompt)
+- `client-secret` → Service Principal OAuth Secret (scope-only; never a job param)
+- `account-console-id` → Account UUID (job param for 0.9+; scope fallback for 0.8.x)
+- `client-id` → Service Principal Application ID (job param for 0.9+; scope fallback)
+- `analysis_schema_name` → Unity Catalog schema, e.g. `catalog.schema` (job param for 0.9+; scope fallback; can also be pre-populated in a BYO scope)
 
 **Storage**: Same Unity Catalog schema as SAT
 - Tables: `brickhound_vertices`, `brickhound_edges`, `brickhound_collection_metadata`
@@ -706,14 +706,14 @@ mcp__databricks__get_job_details(
 ### Key Design Decisions
 
 1. **Namespaced Tables**: `brickhound_` prefix keeps everything in SAT's schema while avoiding conflicts
-2. **Reuse sat_scope**: Simplifies credential management, no new secrets needed
+2. **Reuse SAT scope by default**: Simplifies credential management. In BYO mode (`manage_secrets=false`), `analysis_schema_name` can come from the user's own scope — no new scope needed. When BrickHound is deployed with a BYO credential scope and the schema is not pre-populated there, SAT creates a lightweight `sat_app_scope` holding only that one config value.
 3. **Separate Job**: Allows independent execution, different schedule (weekly vs. 3x/week)
 4. **Keep SDK Separate**: Avoids dependency conflicts (databricks-sdk vs. requests/msal)
 5. **Complementary Analysis**: BrickHound (permissions) + SAT (config) = comprehensive security
 
 ### Integration Points
 
-1. **Configuration**: BrickHound reads `analysis_schema_name` from sat_scope in `00_config.py`
+1. **Configuration**: BrickHound reads `analysis_schema_name` from `json_` (set by `initialize.py` via param→scope resolution) in `00_config.py`
 2. **Authentication**: Uses same service principal as SAT (client-id/client-secret)
 3. **Storage**: Writes to SAT's Unity Catalog schema
 4. **Deployment**: Included in SAT's Terraform deployment (brickhound_job.tf)
@@ -721,9 +721,6 @@ mcp__databricks__get_job_details(
 
 ### Documentation Files
 
-- `docs/BRICKHOUND_INTEGRATION.md` - Integration guide
-- `docs/brickhound_README.md` - Original BrickHound documentation
-- `docs/brickhound_PERMISSIONS.md` - Required permissions
 - `notebooks/brickhound/README.md` - Quick start guide
 
 ### Comparison: SAT vs. BrickHound

--- a/app/brickhound/README.md
+++ b/app/brickhound/README.md
@@ -80,21 +80,29 @@ To find your app's service principal:
 ### Option 1: Databricks Apps (Recommended)
 
 1. **Configure app.yaml**:
+
+   The shipped `app.yaml` uses Databricks Apps resource bindings — no manual values to fill in:
    ```yaml
-   # Update these values in app.yaml
    env:
-     - name: BRICKHOUND_CATALOG
-       value: "your_catalog"  # e.g., "main", "arunuc"
      - name: BRICKHOUND_SCHEMA
-       value: "brickhound"
-     - name: DATABRICKS_WAREHOUSE_HTTP_PATH
-       value: "/sql/1.0/warehouses/abc123def456"
-   
+       valueFrom: "analysis_schema_name"  # bound to a secret resource
+     - name: WAREHOUSE_ID
+       valueFrom: "warehouse"             # bound to the sql_warehouse resource
+
    resources:
-     - name: default-sql-warehouse
+     - name: "analysis_schema_name"
+       secret:
+         permission: "READ"
+         scope: "<sat-scope>"
+         key: analysis_schema_name
+     - name: "warehouse"
        sql_warehouse:
-         id: "abc123def456"  # Your SQL warehouse ID
+         permission: "CAN_USE"
+         id: "<warehouse-id>"
    ```
+   These bindings are declared automatically by the SAT installer (DABS or Terraform).
+   For BYO scope installs, SAT can bind `analysis_schema_name` directly to your scope —
+   see the [Secret Scope Reference](../../docs/sat/docs/installation/secret-scope.mdx).
 
 2. **Deploy via Databricks CLI**:
    ```bash
@@ -214,24 +222,19 @@ Then open http://localhost:8000 in your browser.
 
 ### Environment Variables
 
-**Required:**
-* `DATABRICKS_HOST` - Workspace URL (auto-set in Databricks Apps)
-* `DATABRICKS_TOKEN` - Access token (auto-set in Databricks Apps)
-* `DATABRICKS_WAREHOUSE_HTTP_PATH` - SQL Warehouse HTTP path
+The following env vars are injected at runtime by the Databricks Apps resource bindings
+declared in `app.yaml` — you do not set them manually:
 
-**Optional:**
-* `BRICKHOUND_CATALOG` - Catalog name (default: "arunuc")
-* `BRICKHOUND_SCHEMA` - Schema name (default: "brickhound")
+* `BRICKHOUND_SCHEMA` - Full schema name (`catalog.schema`), from `analysis_schema_name` secret resource
+* `WAREHOUSE_ID` - SQL Warehouse ID, from the `warehouse` sql_warehouse resource
+* `DATABRICKS_HOST` - Workspace URL (auto-set by Databricks Apps runtime)
+* `DATABRICKS_TOKEN` - Access token (auto-set by Databricks Apps runtime)
 
 ### SQL Warehouse
 
-Update `app.yaml` with your SQL Warehouse ID:
-```yaml
-resources:
-  - name: default-sql-warehouse
-    sql_warehouse:
-      id: "<your-warehouse-id>"  # Find in SQL Warehouses → Details
-```
+The warehouse is declared as a resource in `app.yaml` (`name: "warehouse"`).
+The SAT installer sets this to the warehouse you selected during install.
+`WAREHOUSE_ID` resolves automatically from that resource — no hard-coded ID needed.
 
 ## 🔒 Security Notes
 

--- a/app/brickhound/app.yaml
+++ b/app/brickhound/app.yaml
@@ -11,7 +11,7 @@ config:
 
 # Environment variables
 # REQUIRED: Replace placeholders with actual values from your SAT configuration
-# Example: Use full catalog and schema name exaple if your SAT schema is "security_catalog.security_analysis", use:
+# Example: Use full catalog and schema name, e.g. if your SAT schema is "security_catalog.security_analysis", use:
 # BRICKHOUND_SCHEMA: "security_catalog.security_analysis"
 env:
   - name: "PORT"
@@ -19,7 +19,7 @@ env:
   - name: "BRICKHOUND_SCHEMA"
     valueFrom: "analysis_schema_name"
   - name: "WAREHOUSE_ID"
-    valueFrom: "sql-warehouse-id"
+    valueFrom: "warehouse"
 
 # Resource requirements
 resources:

--- a/dabs/dabs_template/databricks_template_schema.json
+++ b/dabs/dabs_template/databricks_template_schema.json
@@ -49,6 +49,60 @@
         "warehouse_id": {
             "type": "string",
             "description": "The ID of the SQL warehouse to use for SAT Permissions Analysis"
+        },
+        "secret_scope": {
+            "type": "string",
+            "description": "Databricks secret scope name that holds SAT credentials",
+            "default": "sat_scope"
+        },
+        "secret_key_names": {
+            "type": "string",
+            "description": "JSON map of logical->physical secret key name overrides (empty = use defaults)",
+            "default": "{}"
+        },
+        "app_config_scope": {
+            "type": "string",
+            "description": "Secret scope used for BrickHound app valueFrom bindings (defaults to secret_scope)",
+            "default": "sat_scope"
+        },
+        "account_id": {
+            "type": "string",
+            "description": "Databricks Account UUID"
+        },
+        "client_id": {
+            "type": "string",
+            "description": "Service Principal Application (client) ID"
+        },
+        "tenant_id": {
+            "type": "string",
+            "description": "Azure Tenant ID (Azure only)"
+        },
+        "subscription_id": {
+            "type": "string",
+            "description": "Azure Subscription ID (Azure only)"
+        },
+        "sql_warehouse_id": {
+            "type": "string",
+            "description": "SQL Warehouse ID for SAT dashboard import"
+        },
+        "analysis_schema_name": {
+            "type": "string",
+            "description": "Unity Catalog schema for SAT tables (catalog.schema)"
+        },
+        "analysis_schema_key": {
+            "type": "string",
+            "description": "Physical secret key name used for the analysis_schema_name app resource binding",
+            "default": "analysis_schema_name"
+        },
+        "proxies": {
+            "type": "string",
+            "description": "JSON proxy map e.g. {\"http\": \"http://proxy:8080\"}",
+            "default": "{}"
+        },
+        "use_sp_auth": {
+            "type": "string",
+            "description": "Use Service Principal auth (true/false, AWS and GCP only)",
+            "default": "false"
         }
     },
     "success_message": ""

--- a/dabs/dabs_template/template/tmp/resources/brickhound_job.yml.tmpl
+++ b/dabs/dabs_template/template/tmp/resources/brickhound_job.yml.tmpl
@@ -19,13 +19,8 @@ resources:
         - name: "analysis_schema_name"
           secret:
             permission: "READ"
-            scope: "sat_scope"
-            key: analysis_schema_name
-        - name: "sql-warehouse-id"
-          secret:
-            permission: "READ"
-            scope: "sat_scope"
-            key: sql-warehouse-id
+            scope: "{{.app_config_scope}}"
+            key: {{.analysis_schema_key}}
   jobs:
     brickhound_data_collection:
       name: "SAT Permissions Analysis - Data Collection (Experimental)"
@@ -48,6 +43,17 @@ resources:
           {{- end }}
           notebook_task:
             notebook_path: "/Workspace/Applications/SAT/files/notebooks/permission_analysis_data_collection"
+            base_parameters:
+              secret_scope: "{{.secret_scope}}"
+              secret_key_names: '{{.secret_key_names}}'
+              account_id_param: "{{.account_id}}"
+              client_id_param: "{{.client_id}}"
+              tenant_id_param: "{{.tenant_id}}"
+              subscription_id_param: "{{.subscription_id}}"
+              sql_warehouse_id_param: "{{.sql_warehouse_id}}"
+              analysis_schema_name_param: "{{.analysis_schema_name}}"
+              proxies_param: '{{.proxies}}'
+              use_sp_auth_param: "{{.use_sp_auth}}"
 
       {{- if eq .serverless false }}
       job_clusters:
@@ -94,6 +100,16 @@ resources:
               last_n_days: "30"
               resource_types: "dashboards,genie,apps"
               remediate: "no"
+              secret_scope: "{{.secret_scope}}"
+              secret_key_names: '{{.secret_key_names}}'
+              account_id_param: "{{.account_id}}"
+              client_id_param: "{{.client_id}}"
+              tenant_id_param: "{{.tenant_id}}"
+              subscription_id_param: "{{.subscription_id}}"
+              sql_warehouse_id_param: "{{.sql_warehouse_id}}"
+              analysis_schema_name_param: "{{.analysis_schema_name}}"
+              proxies_param: '{{.proxies}}'
+              use_sp_auth_param: "{{.use_sp_auth}}"
 
       {{- if eq .serverless false }}
       job_clusters:
@@ -140,6 +156,16 @@ resources:
               finding_types: "account_admin,workspace_admin"
               include_idp_managed: "no"
               remediate: "no"
+              secret_scope: "{{.secret_scope}}"
+              secret_key_names: '{{.secret_key_names}}'
+              account_id_param: "{{.account_id}}"
+              client_id_param: "{{.client_id}}"
+              tenant_id_param: "{{.tenant_id}}"
+              subscription_id_param: "{{.subscription_id}}"
+              sql_warehouse_id_param: "{{.sql_warehouse_id}}"
+              analysis_schema_name_param: "{{.analysis_schema_name}}"
+              proxies_param: '{{.proxies}}'
+              use_sp_auth_param: "{{.use_sp_auth}}"
 
       {{- if eq .serverless false }}
       job_clusters:
@@ -183,6 +209,16 @@ resources:
             base_parameters:
               inactive_days: "90"
               min_inactive: "1"
+              secret_scope: "{{.secret_scope}}"
+              secret_key_names: '{{.secret_key_names}}'
+              account_id_param: "{{.account_id}}"
+              client_id_param: "{{.client_id}}"
+              tenant_id_param: "{{.tenant_id}}"
+              subscription_id_param: "{{.subscription_id}}"
+              sql_warehouse_id_param: "{{.sql_warehouse_id}}"
+              analysis_schema_name_param: "{{.analysis_schema_name}}"
+              proxies_param: '{{.proxies}}'
+              use_sp_auth_param: "{{.use_sp_auth}}"
 
       {{- if eq .serverless false }}
       job_clusters:

--- a/dabs/dabs_template/template/tmp/resources/sat_driver_job.yml.tmpl
+++ b/dabs/dabs_template/template/tmp/resources/sat_driver_job.yml.tmpl
@@ -19,6 +19,17 @@ resources:
           {{- end }}
           notebook_task:
             notebook_path: "/Workspace/Applications/SAT/files/notebooks/security_analysis_driver"
+            base_parameters:
+              secret_scope: "{{.secret_scope}}"
+              secret_key_names: '{{.secret_key_names}}'
+              account_id_param: "{{.account_id}}"
+              client_id_param: "{{.client_id}}"
+              tenant_id_param: "{{.tenant_id}}"
+              subscription_id_param: "{{.subscription_id}}"
+              sql_warehouse_id_param: "{{.sql_warehouse_id}}"
+              analysis_schema_name_param: "{{.analysis_schema_name}}"
+              proxies_param: '{{.proxies}}'
+              use_sp_auth_param: "{{.use_sp_auth}}"
 
       {{- if eq .serverless false }}
       job_clusters:

--- a/dabs/dabs_template/template/tmp/resources/sat_initiliazer_job.yml.tmpl
+++ b/dabs/dabs_template/template/tmp/resources/sat_initiliazer_job.yml.tmpl
@@ -19,6 +19,17 @@ resources:
           {{- end }}
           notebook_task:
             notebook_path: "/Workspace/Applications/SAT/files/notebooks/security_analysis_initializer"
+            base_parameters:
+              secret_scope: "{{.secret_scope}}"
+              secret_key_names: '{{.secret_key_names}}'
+              account_id_param: "{{.account_id}}"
+              client_id_param: "{{.client_id}}"
+              tenant_id_param: "{{.tenant_id}}"
+              subscription_id_param: "{{.subscription_id}}"
+              sql_warehouse_id_param: "{{.sql_warehouse_id}}"
+              analysis_schema_name_param: "{{.analysis_schema_name}}"
+              proxies_param: '{{.proxies}}'
+              use_sp_auth_param: "{{.use_sp_auth}}"
 
       {{- if eq .serverless false }}
       job_clusters:

--- a/dabs/dabs_template/template/tmp/resources/sat_secrets_scanner_job.yml.tmpl
+++ b/dabs/dabs_template/template/tmp/resources/sat_secrets_scanner_job.yml.tmpl
@@ -25,6 +25,17 @@ resources:
           {{- end }}
           notebook_task:
             notebook_path: "/Workspace/Applications/SAT/files/notebooks/security_analysis_secrets_scanner"
+            base_parameters:
+              secret_scope: "{{.secret_scope}}"
+              secret_key_names: '{{.secret_key_names}}'
+              account_id_param: "{{.account_id}}"
+              client_id_param: "{{.client_id}}"
+              tenant_id_param: "{{.tenant_id}}"
+              subscription_id_param: "{{.subscription_id}}"
+              sql_warehouse_id_param: "{{.sql_warehouse_id}}"
+              analysis_schema_name_param: "{{.analysis_schema_name}}"
+              proxies_param: '{{.proxies}}'
+              use_sp_auth_param: "{{.use_sp_auth}}"
 
       {{- if eq .serverless false }}
       job_clusters:

--- a/dabs/main.py
+++ b/dabs/main.py
@@ -3,16 +3,72 @@ import os
 import subprocess
 
 from databricks.sdk import WorkspaceClient
-from sat.config import form, generate_secrets
+from sat.config import (
+    build_secret_key_names,
+    form,
+    generate_secrets,
+    validate_secrets,
+    _resolve_app_config_scope,
+    _resolve_key_overrides,
+)
 from sat.utils import cloud_type
 
 
 def install(client: WorkspaceClient, answers: dict, profile: str):
     cloud = cloud_type(client)
-    generate_secrets(client, answers, cloud)
+    manage = answers.get("manage_secrets", True)
+
+    # Build the structured key-name dict from checkbox + key-name prompt answers
+    # and store it back into answers so _resolve_key_overrides() finds it.
+    key_names_dict = build_secret_key_names(answers, cloud)
+    answers["secret_key_names_dict"] = key_names_dict
+
+    if manage:
+        generate_secrets(client, answers, cloud)
+    else:
+        # Validate that the pre-existing scope has all required keys before
+        # deploying the bundle — fail early with a clear message if not.
+        validate_secrets(client, answers, cloud)
+
+    scope_name = answers.get("secret_scope", "sat_scope") or "sat_scope"
+
+    # Resolve the app config scope using the same logic as config.py so both
+    # the DABS template and the installer write to the same scope.
+    app_config_scope = _resolve_app_config_scope(answers, scope_name, manage)
+
+    scope_contains = answers.get("scope_contains") or []
+
+    def _param(logical, value):
+        """Return blank when the value lives in the user's scope so that
+        initialize.py falls back to reading it from there.  Pass the typed
+        value otherwise so new installs work without a scope for these fields.
+        """
+        return "" if logical in scope_contains else (value or "")
+
+    # Resolve non-secret config values to pass as job base_parameters.
+    schema_deferred = "analysis_schema_name" in scope_contains
+    analysis_schema_name = (
+        ""  # initialize.py resolver reads from scope
+        if schema_deferred
+        else f'`{answers["catalog"]}`.{answers["security_analysis_schema"]}'
+    )
+    # Resolved physical key name for the analysis_schema_name app resource
+    # binding in the bundle template ({{.analysis_schema_key}}).
+    analysis_schema_key = key_names_dict.get("analysis_schema_name", "analysis_schema_name")
+
+    proxies_json = "{}"
+    if answers.get("use_proxy"):
+        proxies_json = json.dumps({
+            "http": answers.get("http", ""),
+            "https": answers.get("https", ""),
+        })
+    elif "proxies" in scope_contains:
+        proxies_json = ""
+
+    use_sp_auth = "true" if cloud in ("aws", "gcp") else "false"
 
     config = {
-        "catalog": answers.get("catalog", None),
+        "catalog": "" if schema_deferred else answers.get("catalog", None),
         "cloud": cloud,
         "latest_lts": client.clusters.select_spark_version(
             long_term_support=True,
@@ -31,7 +87,22 @@ def install(client: WorkspaceClient, answers: dict, profile: str):
         "job_timezone": answers.get("job_timezone", "UTC"),
         "enable_brickhound": answers.get("enable_brickhound", False),
         "brickhound_schedule": answers.get("brickhound_schedule", "0 0 2 * * ?"),
-        "warehouse_id": answers.get("warehouse", []).get("id", None),
+        "warehouse_id": answers.get("warehouse", {}).get("id", None),
+        # BYO scope / key-name config
+        "secret_scope": scope_name,
+        "secret_key_names": json.dumps(key_names_dict) if key_names_dict else "",
+        "app_config_scope": app_config_scope,
+        # Physical key used for the app resource binding (may differ from default).
+        "analysis_schema_key": analysis_schema_key,
+        # Non-secret config values: blank when deferred to the scope.
+        "account_id":              _param("account_id",           answers.get("account_id", "")),
+        "client_id":               _param("client_id",            _resolve_cloud_answer(answers, cloud, "client-id")),
+        "tenant_id":               _param("tenant_id",            answers.get("azure-tenant-id", "")),
+        "subscription_id":         _param("subscription_id",      answers.get("azure-subscription-id", "")),
+        "sql_warehouse_id":        answers.get("warehouse", {}).get("id", ""),
+        "analysis_schema_name":    analysis_schema_name,
+        "proxies":                 proxies_json,
+        "use_sp_auth":             use_sp_auth,
     }
 
     config_file = "tmp_config.json"
@@ -42,6 +113,12 @@ def install(client: WorkspaceClient, answers: dict, profile: str):
     subprocess.call(f"sh ./setup.sh tmp {profile} {config_file}".split(" "))
     print("Installation complete.")
     print(f"Review workspace -> {client.config.host}")
+
+
+def _resolve_cloud_answer(answers: dict, cloud: str, suffix: str) -> str:
+    """Return the cloud-prefixed answer or empty string if not present."""
+    key = f"{cloud}-{suffix}"
+    return answers.get(key, "") or ""
 
 
 def setup():

--- a/dabs/sat/config.py
+++ b/dabs/sat/config.py
@@ -4,7 +4,7 @@ import re
 import subprocess
 
 from databricks.sdk import WorkspaceClient
-from inquirer import Confirm, List, Password, Text, list_input, prompt
+from inquirer import Checkbox, Confirm, List, Password, Text, list_input, prompt
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from sat.utils import (
     cloud_validation,
@@ -15,30 +15,160 @@ from sat.utils import (
     uc_enabled,
 )
 
+# ---------------------------------------------------------------------------
+# Deferrable value catalog
+# ---------------------------------------------------------------------------
+# Each entry: (logical_name, display_label, default_physical_key, cloud_filter)
+#
+# - logical_name         key used in secret_key_names JSON and code
+# - display_label        shown in the checkbox and key-name prompts
+# - default_physical_key default Databricks secret key string
+# - cloud_filter         None = all clouds; "azure"/"aws"/"gcp" = only that cloud
+#
+# Excluded intentionally:
+#   sql_warehouse_id — still used as a notebook scope-fallback for the Setup/5
+#     dashboard import, but no longer a secret the app needs (WAREHOUSE_ID now
+#     resolves from the sql_warehouse resource directly via valueFrom: "warehouse").
+#   use_sp_auth — derived from cloud type, never user-facing.
+DEFERRABLE_VALUES = [
+    ("client_secret",        "Service principal secret (required)", "client-secret",        None),
+    ("account_id",           "Databricks Account ID",               "account-console-id",   None),
+    ("client_id",            "Service principal client ID",         "client-id",             None),
+    ("tenant_id",            "Azure tenant ID",                     "tenant-id",             "azure"),
+    ("subscription_id",      "Azure subscription ID",               "subscription-id",       "azure"),
+    ("proxies",              "Proxy configuration",                  "proxies",              None),
+    ("analysis_schema_name", "Analysis schema (catalog.schema)",    "analysis_schema_name", None),
+]
 
-def form():
-    profile = list_input(
-        message="Select profile",
-        choices=loading(get_profiles, "Loading profiles..."),
-    )
-    client = WorkspaceClient(profile=profile)
-    questions = [
+# Logical names that must always stay in the scope (cannot be deselected).
+_LOCKED_LOGICALS = ["client_secret"]
+
+
+def _deferrable_choices(cloud: str):
+    """Return (label, logical_name) tuples filtered for the active cloud."""
+    return [
+        (label, logical)
+        for logical, label, _key, cloud_filter in DEFERRABLE_VALUES
+        if cloud_filter is None or cloud_filter == cloud
+    ]
+
+
+def _locked_for_cloud(cloud: str):
+    """Return physical choice tuples that must remain selected."""
+    choices = dict(_deferrable_choices(cloud))
+    # locked list must contain the same objects that will appear in choices
+    return [
+        (label, logical)
+        for logical, label, _key, cloud_filter in DEFERRABLE_VALUES
+        if logical in _LOCKED_LOGICALS and (cloud_filter is None or cloud_filter == cloud)
+    ]
+
+
+def _default_physical_key(logical: str) -> str:
+    for lg, _label, key, _cf in DEFERRABLE_VALUES:
+        if lg == logical:
+            return key
+    return logical
+
+
+# ---------------------------------------------------------------------------
+# Question builders — split so tests can import build_questions() directly
+# and exercise the real list without a hand-copied duplicate.
+# ---------------------------------------------------------------------------
+
+def build_questions(client: WorkspaceClient) -> list:
+    """Build the complete inquirer question list for the SAT installer.
+
+    This is the single source of truth.  ``form()`` calls this and passes the
+    result to ``inquirer.prompt()``.  Tests import this directly to run
+    ordering assertions and ignore-callback coverage without a TTY.
+    """
+    from sat.utils import cloud_type as _cloud_type  # local import avoids circular
+
+    cloud = _cloud_type(client)
+
+    # ---- A1 fix: cloud_validation() returns a BOOL, not a callable. ----
+    # Evaluate once; close over the bool value in lambdas so we never call it.
+    skip_azure = cloud_validation(client, "azure")  # True  when NOT azure
+    skip_gcp   = cloud_validation(client, "gcp")
+    skip_aws   = cloud_validation(client, "aws")
+
+    # Choices and locked sets for the scope_contains checkbox.
+    byo_choices = _deferrable_choices(cloud)
+    byo_locked  = _locked_for_cloud(cloud)
+
+    # ---- Core questions ----
+    # secret_scope / manage_secrets come FIRST so every subsequent ignore
+    # lambda can read them from the already-answered dict.
+    core = [
+        Text(
+            name="secret_scope",
+            message="Secret scope name",
+            default="sat_scope",
+        ),
+        Confirm(
+            name="manage_secrets",
+            message="Let SAT write the service principal secret to this scope?",
+            default=True,
+        ),
+    ]
+
+    # ---- BYO scope: checkbox + per-key prompts ----
+    # scope_contains: which logical values live in the existing scope?
+    # Shown only when manage_secrets=False.  client_secret is locked (always in scope).
+    byo_scope = [
+        Checkbox(
+            name="scope_contains",
+            message="Which values are already in your scope? (Space=toggle)",
+            choices=byo_choices,
+            locked=byo_locked,
+            default=byo_locked,
+            ignore=lambda x: x.get("manage_secrets", True),
+        ),
+    ]
+
+    # One Text prompt per deferrable entry to collect the physical key name.
+    # Shown only when that logical name was checked in scope_contains.
+    # IMPORTANT: use lg=lg default-arg binding to capture the loop variable;
+    # a bare closure would make every lambda see the last value of lg.
+    byo_key_names = [
+        Text(
+            name=f"key_name__{lg}",
+            message=f"Secret scope key name for: {label}",
+            default=default_key,
+            ignore=lambda x, lg=lg: lg not in (x.get("scope_contains") or []),
+        )
+        for lg, label, default_key, cloud_filter in DEFERRABLE_VALUES
+        if cloud_filter is None or cloud_filter == cloud
+    ]
+
+    # ---- Non-secret config values ----
+    # account_id / client_id / tenant_id / subscription_id: suppressed when the
+    # user said those values are already in their scope.
+    # catalog / security_analysis_schema: suppressed when analysis_schema_name is
+    # deferred — the installer has no need for the component parts if the full
+    # catalog.schema string comes from the user's existing scope key.
+    _schema_deferred = lambda x: "analysis_schema_name" in (x.get("scope_contains") or [])
+    config_values = [
         Text(
             name="account_id",
             message="Databricks Account ID",
             validate=lambda _, x: re.match(
                 r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", x
             ),
+            ignore=lambda x: "account_id" in (x.get("scope_contains") or []),
         ),
         List(
             name="catalog",
             message="Select catalog",
             choices=loading(get_catalogs, client=client),
+            ignore=_schema_deferred,
         ),
         Text(
             name="security_analysis_schema",
             message="Schema name for SAT",
             default="security_analysis",
+            ignore=_schema_deferred,
         ),
         Confirm(
             name="enable_serverless",
@@ -51,27 +181,86 @@ def form():
             choices=loading(get_warehouses, client=client),
         ),
     ]
+
+    # ---- Cloud-specific credential questions ----
+    # client-id is a non-secret param: always ask unless in-scope or wrong cloud.
+    # client-secret is a secret: ask only when manage_secrets=True AND right cloud.
+    azure_qs = [
+        Text(
+            name="azure-tenant-id",
+            message="Azure Tenant ID",
+            ignore=lambda x: skip_azure or "tenant_id" in (x.get("scope_contains") or []),
+        ),
+        Text(
+            name="azure-subscription-id",
+            message="Azure Subscription ID",
+            ignore=lambda x: skip_azure or "subscription_id" in (x.get("scope_contains") or []),
+        ),
+        Text(
+            name="azure-client-id",
+            message="SAT service principal Client ID",
+            ignore=lambda x: skip_azure or "client_id" in (x.get("scope_contains") or []),
+        ),
+        Password(
+            name="azure-client-secret",
+            message="SAT service principal Client Secret",
+            ignore=lambda x: skip_azure or not x.get("manage_secrets", True),
+            echo="",
+        ),
+    ]
+    gcp_qs = [
+        Text(
+            name="gcp-client-id",
+            message="SAT service principal Client ID",
+            ignore=lambda x: skip_gcp or "client_id" in (x.get("scope_contains") or []),
+        ),
+        Password(
+            name="gcp-client-secret",
+            message="SAT service principal Client Secret",
+            ignore=lambda x: skip_gcp or not x.get("manage_secrets", True),
+            echo="",
+        ),
+    ]
+    aws_qs = [
+        Text(
+            name="aws-client-id",
+            message="SAT service principal Client ID",
+            ignore=lambda x: skip_aws or "client_id" in (x.get("scope_contains") or []),
+        ),
+        Password(
+            name="aws-client-secret",
+            message="SAT service principal Client Secret",
+            ignore=lambda x: skip_aws or not x.get("manage_secrets", True),
+            echo="",
+        ),
+    ]
+
+    # ---- Proxy questions ----
+    # proxies suppressed if the user flagged it as already in their scope.
     proxies = [
         Confirm(
             name="use_proxy",
             message="Want to use a proxy?",
             default=False,
+            ignore=lambda x: "proxies" in (x.get("scope_contains") or []),
         ),
         Text(
             name="http",
             message="HTTP Proxy",
-            ignore=lambda x: not x["use_proxy"],
+            ignore=lambda x: "proxies" in (x.get("scope_contains") or [])
+                             or not x.get("use_proxy", False),
             default="",
         ),
         Text(
             name="https",
             message="HTTPS Proxy",
-            ignore=lambda x: not x["use_proxy"],
+            ignore=lambda x: "proxies" in (x.get("scope_contains") or [])
+                             or not x.get("use_proxy", False),
             default="",
         ),
     ]
 
-    # Job Scheduling Configuration
+    # ---- Scheduling ----
     scheduling = [
         Text(
             name="driver_schedule",
@@ -79,7 +268,7 @@ def form():
             default="0 0 8 ? * Mon,Wed,Fri",
         ),
         Text(
-            name="secrets_scanner_schedule", 
+            name="secrets_scanner_schedule",
             message="Secrets scanner job schedule (Quartz cron expression)",
             default="0 0 8 ? * *",
         ),
@@ -90,7 +279,7 @@ def form():
         ),
     ]
 
-    # Permissions Analysis Configuration
+    # ---- Permissions Analysis (BrickHound) ----
     brickhound = [
         Confirm(
             name="enable_brickhound",
@@ -105,66 +294,194 @@ def form():
         ),
     ]
 
-    questions = questions + cloud_specific_questions(client) + proxies + scheduling + brickhound
-    return client, prompt(questions), profile
+    # app_config_scope MUST come after enable_brickhound so the ignore lambda
+    # can read the already-answered value from the answers dict.
+    #
+    # Both ignore and default delegate to _needs_app_config_scope() — the single
+    # predicate that decides whether SAT must create a separate scope.  Keeping
+    # them in sync prevents the mismatch where ignore=hidden but default returns
+    # a non-blank value, which previously caused the app resource to bind to a
+    # scope SAT never created (sat_app_scope 404 crash).
+    #
+    # default MUST be a callable: ConsoleRender.render() stores question.default
+    # even for ignored questions (console/__init__.py:29-30).  A static string
+    # would let the explicit-answer branch in _resolve_app_config_scope shadow
+    # the deferral branch regardless of scope_contains.
+    app_config = [
+        Text(
+            name="app_config_scope",
+            message="Scope SAT will create for Permissions Analysis app config (non-secret)",
+            default=lambda x: "sat_app_scope" if _needs_app_config_scope(x) else "",
+            ignore=lambda x: not _needs_app_config_scope(x),
+        ),
+    ]
+
+    return (
+        core
+        + byo_scope
+        + byo_key_names
+        + config_values
+        + aws_qs + azure_qs + gcp_qs
+        + proxies
+        + scheduling
+        + brickhound
+        + app_config
+    )
 
 
-def cloud_specific_questions(client: WorkspaceClient):
-    azure = [
-        Text(
-            name="azure-tenant-id",
-            message="Azure Tenant ID",
-            ignore=cloud_validation(client, "azure"),
-        ),
-        Text(
-            name="azure-subscription-id",
-            message="Azure Subscription ID",
-            ignore=cloud_validation(client, "azure"),
-        ),
-        Text(
-            name="azure-client-id",
-            message="Client ID",
-            ignore=cloud_validation(client, "azure"),
-        ),
-        Password(
-            name="azure-client-secret",
-            message="Client Secret",
-            ignore=cloud_validation(client, "azure"),
-            echo="",
-        ),
-    ]
-    gcp = [
-        Text(
-            name="gcp-client-id",
-            message="Client ID",
-            ignore=cloud_validation(client, "gcp"),
-        ),
-        Password(
-            name="gcp-client-secret",
-            message="Client Secret",
-            ignore=cloud_validation(client, "gcp"),
-            echo="",
-        ),
-    ]
-    aws = [
-        Text(
-            name="aws-client-id",
-            message="Client ID",
-            ignore=cloud_validation(client, "aws"),
-        ),
-        Password(
-            name="aws-client-secret",
-            message="Client Secret",
-            ignore=cloud_validation(client, "aws"),
-            echo="",
-        ),
-    ]
-    return aws + azure + gcp
+def form():
+    profile = list_input(
+        message="Select profile",
+        choices=loading(get_profiles, "Loading profiles..."),
+    )
+    client = WorkspaceClient(profile=profile)
+    return client, prompt(build_questions(client)), profile
+
+
+# ---------------------------------------------------------------------------
+# Secret key name assembly — called from main.py
+# ---------------------------------------------------------------------------
+
+def build_secret_key_names(answers: dict, cloud: str) -> dict:
+    """Build the secret_key_names dict from structured prompt answers.
+
+    For each logical name the user checked in scope_contains, use the
+    corresponding key_name__<logical> answer (or fall back to the default
+    physical key name).  Returns a dict suitable for JSON serialisation and
+    injection into tmp_config.json / job base_parameters.
+    """
+    scope_contains = answers.get("scope_contains") or []
+    result = {}
+    for lg, _label, default_key, cloud_filter in DEFERRABLE_VALUES:
+        if cloud_filter is not None and cloud_filter != cloud:
+            continue
+        if lg in scope_contains:
+            result[lg] = answers.get(f"key_name__{lg}") or default_key
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_key_overrides(answers: dict) -> dict:
+    """Return the merged key-override dict from answers.
+
+    Accepts either the structured dict built by build_secret_key_names()
+    (stored under 'secret_key_names_dict') or the legacy JSON string
+    stored under 'secret_key_names'.  Returns empty dict on any error.
+    """
+    # Structured path (new): a plain dict stored directly.
+    if isinstance(answers.get("secret_key_names_dict"), dict):
+        return answers["secret_key_names_dict"]
+    # Legacy / Terraform path: a JSON string.
+    raw = answers.get("secret_key_names", "") or ""
+    if not raw.strip():
+        return {}
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+
+
+def _needs_app_config_scope(answers: dict) -> bool:
+    """True only when SAT must create/write a separate scope for the app's schema key.
+
+    Used as the single source of truth for both the ignore lambda and the default
+    lambda of the app_config_scope prompt.  Keeping both in sync here prevents the
+    "ignore says hidden but default returns non-blank" mismatch that caused the
+    sat_app_scope/404 crash when analysis_schema_name was deferred.
+
+    Conditions that make a separate scope unnecessary:
+    - BrickHound is not being deployed (no app)
+    - manage_secrets=True: the key is written to the main scope
+    - analysis_schema_name is in scope_contains: key lives in the user's scope,
+      app binds there directly — SAT writes nothing, no new scope needed
+    """
+    if not answers.get("enable_brickhound", False):
+        return False
+    if answers.get("manage_secrets", True):
+        return False
+    if "analysis_schema_name" in (answers.get("scope_contains") or []):
+        return False
+    return True
+
+
+def _resolve_app_config_scope(answers: dict, scope_name: str, manage_secrets: bool) -> str:
+    """Return the scope that holds the BrickHound app's analysis_schema_name key.
+
+    Resolution order (mirrors terraform/common/locals.tf):
+    1. analysis_schema_name deferred to user's scope → scope_name directly.
+       This takes precedence over any explicit answer because the user's prompt
+       default was pre-filled with "sat_app_scope" and pressing Enter without
+       clearing it would otherwise route to a scope SAT never created.
+    2. manage_secrets=True → scope_name (key lives in the main scope).
+    3. Explicit app_config_scope answer (non-blank, non-default) → use it.
+    4. Fallback → "sat_app_scope" (SAT creates and owns it; credential scope untouched).
+    """
+    scope_contains = answers.get("scope_contains") or []
+    if "analysis_schema_name" in scope_contains:
+        return scope_name
+    if manage_secrets:
+        return scope_name
+    explicit = (answers.get("app_config_scope") or "").strip()
+    if explicit and explicit != "sat_app_scope":
+        return explicit
+    return explicit or "sat_app_scope"
+
+
+def ensure_app_config_secrets(
+    client: WorkspaceClient,
+    answers: dict,
+    scope_name: str,
+    manage_secrets: bool,
+    key_overrides: dict,
+    existing_scopes: set,
+) -> None:
+    """Write analysis_schema_name to the app config scope when needed.
+
+    WAREHOUSE_ID is no longer written here — app.yaml uses valueFrom: "warehouse"
+    which resolves from the sql_warehouse resource directly (no secret needed).
+
+    Skipped entirely when:
+    - BrickHound is not being deployed, OR
+    - analysis_schema_name is already in the user's scope (scope_contains).
+
+    Called from both manage_secrets=True and manage_secrets=False paths.
+    """
+    if not answers.get("enable_brickhound", False):
+        return
+
+    scope_contains = answers.get("scope_contains") or []
+    if "analysis_schema_name" in scope_contains:
+        # Key is pre-populated in the user's scope; SAT must not write to it.
+        return
+
+    app_scope = _resolve_app_config_scope(answers, scope_name, manage_secrets)
+
+    if app_scope not in existing_scopes:
+        client.secrets.create_scope(app_scope)
+
+    analysis_schema_key = key_overrides.get("analysis_schema_name", "analysis_schema_name")
+    client.secrets.put_secret(
+        scope=app_scope,
+        key=analysis_schema_key,
+        string_value=f'`{answers["catalog"]}`.{answers["security_analysis_schema"]}',
+    )
 
 
 def generate_secrets(client: WorkspaceClient, answers: dict, cloud_type: str):
+    """Create the SAT secret scope (if absent) and write only the credential secret.
 
-    scope_name = "sat_scope"
+    Non-secret config values (account_id, client_id, sql_warehouse_id, etc.) are
+    now passed as direct job base_parameters via the bundle template — not stored
+    in the scope.  Only ``client-secret`` (and cloud-equivalent) is written here
+    because it is an actual credential that must not travel through job parameters.
+    """
+    scope_name = answers.get("secret_scope", "sat_scope") or "sat_scope"
+    key_overrides = _resolve_key_overrides(answers)
+    client_secret_key = key_overrides.get("client_secret", "client-secret")
+
     # Only create the scope if it doesn't already exist. Previous versions
     # deleted and recreated the scope on every install, which wiped ACLs —
     # including the READ ACL that Databricks Apps auto-creates when a
@@ -176,51 +493,67 @@ def generate_secrets(client: WorkspaceClient, answers: dict, cloud_type: str):
     if scope_name not in existing:
         client.secrets.create_scope(scope_name)
 
-    client.secrets.put_secret(
-        scope=scope_name,
-        key="account-console-id",
-        string_value=answers["account_id"],
-    )
-    client.secrets.put_secret(
-        scope=scope_name,
-        key="sql-warehouse-id",
-        string_value=answers["warehouse"]["id"],
-    )
-    client.secrets.put_secret(
-        scope=scope_name,
-        key="analysis_schema_name",
-        string_value=f'`{answers["catalog"]}`.{answers["security_analysis_schema"]}',
-    )
-
-    if answers["use_proxy"]:
-        client.secrets.put_secret(
-            scope=scope_name,
-            key="proxies",
-            string_value=json.dumps(
-                {
-                    "http": answers["http"],
-                    "https": answers["https"],
-                }
-            ),
-        )
-    else:
-        client.secrets.put_secret(
-            scope=scope_name,
-            key="proxies",
-            string_value="{}",
-        )
-
-    if cloud_type == "aws" or cloud_type == "gcp":
-        client.secrets.put_secret(
-            scope=scope_name,
-            key="use-sp-auth",
-            string_value=True,
-        )
-
+    # Write only the credential secret — the only value that must remain in the scope.
     for value in answers.keys():
-        if cloud_type in value:
+        if cloud_type in value and value.endswith("-client-secret"):
             client.secrets.put_secret(
                 scope=scope_name,
-                key=value.replace(f"{cloud_type}-", ""),
+                key=client_secret_key,
                 string_value=answers[value],
             )
+            break
+
+    # Always ensure app config secrets exist for BrickHound regardless of
+    # manage_secrets; extracted so the BYO path also calls this.
+    ensure_app_config_secrets(client, answers, scope_name, True, key_overrides, existing)
+
+
+def validate_secrets(client: WorkspaceClient, answers: dict, cloud_type: str) -> None:
+    """Validate that a pre-existing scope has all the keys SAT needs.
+
+    Called when ``manage_secrets=False``.  Raises ``ValueError`` (caught by the
+    ``except Exception`` in main.py) with the full list of missing keys before
+    bundle deploy is attempted.
+    """
+    scope_name = answers.get("secret_scope", "sat_scope") or "sat_scope"
+    key_overrides = _resolve_key_overrides(answers)
+
+    # Check scope exists.
+    existing = {scope.name for scope in client.secrets.list_scopes()}
+    if scope_name not in existing:
+        raise ValueError(
+            f"Secret scope '{scope_name}' does not exist. "
+            f"Create it first or set manage_secrets=True to let SAT create it."
+        )
+
+    # Validate every key the user declared is in the scope — report all
+    # missing at once rather than stopping at the first failure.
+    scope_contains = answers.get("scope_contains") or []
+    missing = []
+    for lg, _label, default_key, cloud_filter in DEFERRABLE_VALUES:
+        if cloud_filter is not None and cloud_filter != cloud_type:
+            continue
+        if lg not in scope_contains:
+            continue
+        physical = key_overrides.get(lg, default_key)
+        try:
+            result = client.secrets.get_secret(scope=scope_name, key=physical)
+            if not result.value:
+                missing.append(
+                    f"  - {lg} (scope='{scope_name}', key='{physical}'): empty value"
+                )
+        except Exception as exc:
+            missing.append(
+                f"  - {lg} (scope='{scope_name}', key='{physical}'): {exc}"
+            )
+
+    if missing:
+        raise ValueError(
+            "The following required secrets are missing from scope "
+            f"'{scope_name}':\n" + "\n".join(missing) + "\n"
+            "Please populate these keys before re-running the installer."
+        )
+
+    # Still ensure app config secrets exist for BrickHound even when
+    # the user brings their own credential scope.
+    ensure_app_config_secrets(client, answers, scope_name, False, key_overrides, existing)

--- a/dabs/tests/test_config.py
+++ b/dabs/tests/test_config.py
@@ -1,0 +1,913 @@
+"""
+Tests for dabs/sat/config.py — non-interactive, no workspace connection needed.
+
+Coverage
+--------
+- Prompt rendering safety: no message/default may contain bare { } braces.
+  inquirer calls str.format(**answers) on both strings.
+- Question ordering: every question that gates on a prior answer must appear
+  after that prior question.
+- ignore-callable coverage: invoke every ignore lambda against realistic
+  answer dicts (full, partial, manage_secrets=False) and assert behaviour.
+- build_secret_key_names: checkbox selections + key answers -> expected dict.
+- _resolve_key_overrides: blank / empty JSON / valid JSON / bad JSON.
+- _resolve_app_config_scope: all three resolution branches.
+- validate_secrets: correct SDK call signature (scope=, key=) not path=;
+  reports all missing keys at once.
+"""
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# ---------------------------------------------------------------------------
+# Path setup — must happen before any sat.* imports
+# ---------------------------------------------------------------------------
+_DABS_DIR = Path(__file__).parent.parent
+if str(_DABS_DIR) not in sys.path:
+    sys.path.insert(0, str(_DABS_DIR))
+
+# ---------------------------------------------------------------------------
+# Minimal stubs — must match the real module contracts
+# ---------------------------------------------------------------------------
+
+def _make_stub_module(name, **attrs):
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+
+# Third-party stubs
+for _name in ("rich", "rich.progress", "databricks", "databricks.sdk"):
+    sys.modules.setdefault(_name, _make_stub_module(_name))
+
+_inquirer = sys.modules.setdefault("inquirer", _make_stub_module("inquirer"))
+
+for _cls_name in ("Text", "Password", "Confirm", "List", "Checkbox"):
+    if not hasattr(_inquirer, _cls_name):
+        def _make_cls(n):
+            class _Q:
+                kind = n.lower()
+                def __init__(self, name, message="", default=None,
+                             ignore=None, choices=None, locked=None,
+                             validate=True, echo="*", **kw):
+                    self.name    = name
+                    self._message = message
+                    self._default = default
+                    self._ignore  = ignore
+                    self.choices  = choices
+                    self.locked   = locked
+            _Q.__name__ = n
+            return _Q
+        setattr(_inquirer, _cls_name, _make_cls(_cls_name))
+
+if not hasattr(_inquirer, "list_input"):
+    _inquirer.list_input = lambda message="", choices=None, **kw: ""
+if not hasattr(_inquirer, "prompt"):
+    _inquirer.prompt = lambda questions, **kw: {}
+
+_progress_cls = type("Progress", (), {
+    "__init__": lambda self, *a, **k: None,
+    "__enter__": lambda self: self,
+    "__exit__": lambda self, *a: None,
+    "add_task": lambda self, *a, **k: 0,
+    "start": lambda self: None,
+    "stop": lambda self: None,
+})
+sys.modules["rich.progress"].__dict__.update({
+    "Progress": _progress_cls,
+    "SpinnerColumn": object,
+    "TextColumn": object,
+})
+
+_ws_stub = type("WorkspaceClient", (), {"__init__": lambda self, **kw: None})
+sys.modules["databricks.sdk"].__dict__["WorkspaceClient"] = _ws_stub
+
+# A3 fix: cloud_validation returns a BOOL (True = skip / not this cloud).
+# Simulate an AWS workspace so azure/gcp are skipped, aws is active.
+_utils_stub = _make_stub_module(
+    "sat.utils",
+    cloud_validation=lambda client, cloud: cloud != "aws",  # bool, not callable
+    get_catalogs=lambda **kw: [],
+    get_profiles=lambda: [],
+    get_warehouses=lambda **kw: [],
+    loading=lambda f, *a, **k: [],
+    uc_enabled=lambda client: False,
+    cloud_type=lambda client: "aws",
+)
+sys.modules["sat.utils"] = _utils_stub
+
+from sat import config  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture — representative answer dict for an AWS workspace
+# ---------------------------------------------------------------------------
+
+FULL_ANSWERS_MANAGE = {
+    "secret_scope": "sat_scope",
+    "manage_secrets": True,
+    "scope_contains": [],
+    "key_name__client_secret": "client-secret",
+    "key_name__account_id": "account-console-id",
+    "key_name__client_id": "client-id",
+    "key_name__proxies": "proxies",
+    "account_id": "12345678-1234-1234-1234-123456789abc",
+    "catalog": "main",
+    "security_analysis_schema": "security_analysis",
+    "enable_serverless": True,
+    "warehouse": {"id": "abcd1234abcd1234", "name": "SAT WH"},
+    "aws-client-id": "sp-client-id",
+    "aws-client-secret": "sp-client-secret",
+    "azure-tenant-id": "",
+    "azure-subscription-id": "",
+    "azure-client-id": "",
+    "azure-client-secret": "",
+    "gcp-client-id": "",
+    "gcp-client-secret": "",
+    "use_proxy": False,
+    "http": "",
+    "https": "",
+    "driver_schedule": "0 0 8 ? * Mon,Wed,Fri",
+    "secrets_scanner_schedule": "0 0 8 ? * *",
+    "job_timezone": "UTC",
+    "enable_brickhound": True,
+    "brickhound_schedule": "0 0 2 ? * *",
+    "app_config_scope": "",
+}
+
+# BYO path: manage_secrets=False, account_id and client_id deferred to scope
+FULL_ANSWERS_BYO = {
+    **FULL_ANSWERS_MANAGE,
+    "manage_secrets": False,
+    "scope_contains": ["client_secret", "account_id", "client_id"],
+    "account_id": "",   # suppressed by ignore, so blank
+}
+
+
+def _build():
+    """Build the real question list against a mock AWS client."""
+    client = MagicMock()
+    client.config = MagicMock()
+    client.config.host = "https://adb-test.cloud.databricks.com"
+    return config.build_questions(client)
+
+
+# ---------------------------------------------------------------------------
+# Helper: invoke an ignore (bool or callable) safely
+# ---------------------------------------------------------------------------
+
+def _eval_ignore(q, answers):
+    ig = q._ignore
+    if ig is None:
+        return False
+    if callable(ig):
+        return ig(answers)
+    return bool(ig)
+
+
+def _eval_default(q, answers):
+    """Resolve a question's default, handling callables (like app_config_scope)."""
+    d = q._default
+    if callable(d):
+        return d(answers)
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+class TestPromptRenderingSafety(unittest.TestCase):
+    """inquirer calls str.format(**answers) on every string message and default.
+    Callable messages/defaults bypass str.format entirely — skip those.
+    """
+
+    # Max message length before inquirer truncates at width-9 chars on an
+    # 80-column terminal.  _print_header truncates when len(base) > width-6.
+    MAX_MSG_LEN = 74
+
+    def _render(self, s, label, answers):
+        try:
+            s.format(**answers)
+        except (IndexError, KeyError) as exc:
+            self.fail(
+                f"Question '{label}' has unsafe braces in {s!r}: {exc}\n"
+                "Escape literal braces as {{{{ / }}}}, or remove them."
+            )
+
+    def test_all_string_messages_and_defaults_are_format_safe(self):
+        for answers in (FULL_ANSWERS_MANAGE, FULL_ANSWERS_BYO):
+            for q in _build():
+                for attr, label in (("_message", "message"), ("_default", "default")):
+                    val = getattr(q, attr, None)
+                    if isinstance(val, str):
+                        self._render(val, f"{q.name}.{label}", answers)
+
+    def test_all_messages_under_truncation_width(self):
+        """No string message may exceed MAX_MSG_LEN chars.
+
+        inquirer._print_header truncates at width-9 on an 80-col terminal
+        (effective threshold ≈ 74 chars). A truncated message mid-word
+        signals a wording problem.  Callable messages are exempt — their
+        return value is checked separately.
+        """
+        for q in _build():
+            msg = q._message
+            if not isinstance(msg, str):
+                continue
+            self.assertLessEqual(
+                len(msg), self.MAX_MSG_LEN,
+                f"Question '{q.name}' message is {len(msg)} chars (max {self.MAX_MSG_LEN}): {msg!r}"
+            )
+
+
+class TestQuestionOrdering(unittest.TestCase):
+    """Gating questions must precede the questions that depend on them."""
+
+    def _names(self):
+        return [q.name for q in _build()]
+
+    def _assert_before(self, earlier, later):
+        names = self._names()
+        ei = names.index(earlier)
+        li = names.index(later)
+        self.assertLess(
+            ei, li,
+            f"'{earlier}' (pos {ei}) must precede '{later}' (pos {li})"
+        )
+
+    def test_manage_secrets_before_scope_contains(self):
+        self._assert_before("manage_secrets", "scope_contains")
+
+    def test_scope_contains_before_key_name_prompts(self):
+        names = self._names()
+        sc_idx = names.index("scope_contains")
+        key_prompts = [n for n in names if n.startswith("key_name__")]
+        self.assertTrue(key_prompts, "No key_name__ prompts found")
+        for kp in key_prompts:
+            self.assertLess(sc_idx, names.index(kp),
+                            f"scope_contains must precede {kp}")
+
+    def test_scope_contains_before_account_id(self):
+        self._assert_before("scope_contains", "account_id")
+
+    def test_enable_brickhound_before_app_config_scope(self):
+        self._assert_before("enable_brickhound", "app_config_scope")
+
+    def test_secret_scope_before_manage_secrets(self):
+        self._assert_before("secret_scope", "manage_secrets")
+
+
+class TestIgnoreCallables(unittest.TestCase):
+    """A4: invoke every ignore against real answer dicts; assert behaviour."""
+
+    def test_no_ignore_raises_on_full_answers(self):
+        """No ignore callable should crash on either full answer set."""
+        for answers in (FULL_ANSWERS_MANAGE, FULL_ANSWERS_BYO):
+            for q in _build():
+                try:
+                    _eval_ignore(q, answers)
+                except Exception as exc:
+                    self.fail(
+                        f"ignore for '{q.name}' raised with answers: {exc}"
+                    )
+
+    def test_no_ignore_raises_on_partial_answers(self):
+        """Simulate mid-prompt state: only the first N answers are populated."""
+        questions = _build()
+        partial = {}
+        for q in questions:
+            try:
+                _eval_ignore(q, partial)
+            except Exception as exc:
+                self.fail(
+                    f"ignore for '{q.name}' raised on partial answers {partial}: {exc}"
+                )
+            # Simulate answering this question (resolve callable defaults too).
+            default_val = _eval_default(q, partial)
+            if default_val is not None:
+                partial[q.name] = default_val
+            elif q.name == "scope_contains":
+                partial[q.name] = []
+            elif q.name == "warehouse":
+                partial[q.name] = {"id": "abcd1234abcd1234"}
+            else:
+                partial[q.name] = ""
+
+    def test_client_secret_hidden_when_byo(self):
+        """aws-client-secret must be ignored when manage_secrets=False."""
+        questions = {q.name: q for q in _build()}
+        q = questions["aws-client-secret"]
+        self.assertTrue(
+            _eval_ignore(q, FULL_ANSWERS_BYO),
+            "aws-client-secret should be ignored when manage_secrets=False"
+        )
+
+    def test_client_secret_shown_when_managed(self):
+        """aws-client-secret must NOT be ignored when manage_secrets=True."""
+        questions = {q.name: q for q in _build()}
+        q = questions["aws-client-secret"]
+        self.assertFalse(
+            _eval_ignore(q, FULL_ANSWERS_MANAGE),
+            "aws-client-secret should NOT be ignored when manage_secrets=True"
+        )
+
+    def test_account_id_hidden_when_in_scope(self):
+        questions = {q.name: q for q in _build()}
+        q = questions["account_id"]
+        answers = {**FULL_ANSWERS_BYO, "scope_contains": ["client_secret", "account_id"]}
+        self.assertTrue(_eval_ignore(q, answers))
+
+    def test_account_id_shown_when_not_in_scope(self):
+        questions = {q.name: q for q in _build()}
+        q = questions["account_id"]
+        answers = {**FULL_ANSWERS_BYO, "scope_contains": ["client_secret"]}
+        self.assertFalse(_eval_ignore(q, answers))
+
+    def test_scope_contains_shown_when_byo(self):
+        questions = {q.name: q for q in _build()}
+        q = questions["scope_contains"]
+        self.assertFalse(_eval_ignore(q, FULL_ANSWERS_BYO))
+
+    def test_scope_contains_hidden_when_managed(self):
+        questions = {q.name: q for q in _build()}
+        q = questions["scope_contains"]
+        self.assertTrue(_eval_ignore(q, FULL_ANSWERS_MANAGE))
+
+    def test_azure_questions_hidden_on_aws(self):
+        """All azure-* questions must be ignored on an AWS workspace."""
+        questions = _build()
+        azure_qs = [q for q in questions if q.name.startswith("azure-")]
+        self.assertTrue(azure_qs, "No azure-* questions found")
+        for q in azure_qs:
+            self.assertTrue(
+                _eval_ignore(q, FULL_ANSWERS_MANAGE),
+                f"azure question '{q.name}' should be ignored on AWS"
+            )
+
+    def test_key_name_hidden_when_not_in_scope(self):
+        """key_name__account_id must be ignored when account_id not in scope_contains."""
+        questions = {q.name: q for q in _build()}
+        q = questions.get("key_name__account_id")
+        if q is None:
+            self.skipTest("key_name__account_id not in question list (cloud filtered)")
+        answers = {**FULL_ANSWERS_MANAGE, "scope_contains": ["client_secret"]}
+        self.assertTrue(_eval_ignore(q, answers))
+
+    def test_key_name_shown_when_in_scope(self):
+        questions = {q.name: q for q in _build()}
+        q = questions.get("key_name__account_id")
+        if q is None:
+            self.skipTest("key_name__account_id not in question list (cloud filtered)")
+        answers = {**FULL_ANSWERS_MANAGE, "scope_contains": ["client_secret", "account_id"]}
+        self.assertFalse(_eval_ignore(q, answers))
+
+    # ---- app_config_scope visibility and default ----
+
+    def test_app_config_scope_hidden_when_managed(self):
+        """Managed installs never need this prompt; SAT uses the main scope."""
+        questions = {q.name: q for q in _build()}
+        q = questions["app_config_scope"]
+        answers = {**FULL_ANSWERS_MANAGE, "enable_brickhound": True}
+        self.assertTrue(
+            _eval_ignore(q, answers),
+            "app_config_scope should be hidden when manage_secrets=True"
+        )
+
+    def test_app_config_scope_shown_when_byo_with_brickhound(self):
+        """BYO + BrickHound: user needs to confirm or change the scope name."""
+        questions = {q.name: q for q in _build()}
+        q = questions["app_config_scope"]
+        answers = {**FULL_ANSWERS_BYO, "enable_brickhound": True}
+        self.assertFalse(
+            _eval_ignore(q, answers),
+            "app_config_scope should be shown when manage_secrets=False and enable_brickhound=True"
+        )
+
+    def test_app_config_scope_hidden_when_brickhound_off(self):
+        """No BrickHound deployed means no app and no scope needed."""
+        questions = {q.name: q for q in _build()}
+        q = questions["app_config_scope"]
+        for answers in (
+            {**FULL_ANSWERS_MANAGE, "enable_brickhound": False},
+            {**FULL_ANSWERS_BYO,    "enable_brickhound": False},
+        ):
+            self.assertTrue(
+                _eval_ignore(q, answers),
+                "app_config_scope should be hidden when enable_brickhound=False"
+            )
+
+    def test_app_config_scope_default_blank_when_managed(self):
+        """Regression guard: ignored managed questions must return '' not 'sat_app_scope'.
+
+        ConsoleRender.render() (console/__init__.py:29-30) stores question.default
+        even for ignored questions.  A static 'sat_app_scope' default would make
+        managed installs create a second scope silently.
+        """
+        questions = {q.name: q for q in _build()}
+        q = questions["app_config_scope"]
+        default = _eval_default(q, {**FULL_ANSWERS_MANAGE, "enable_brickhound": True})
+        self.assertEqual(
+            default, "",
+            f"Managed install default must be '' not {default!r}"
+        )
+
+    def test_app_config_scope_default_is_sat_app_scope_when_byo(self):
+        """BYO: pre-filled value must be 'sat_app_scope' so user can accept or edit."""
+        questions = {q.name: q for q in _build()}
+        q = questions["app_config_scope"]
+        default = _eval_default(q, {**FULL_ANSWERS_BYO, "enable_brickhound": True})
+        self.assertEqual(
+            default, "sat_app_scope",
+            f"BYO default must be 'sat_app_scope' not {default!r}"
+        )
+
+
+class TestBuildSecretKeyNames(unittest.TestCase):
+    """A2/B: build_secret_key_names assembles key map from checkbox answers."""
+
+    def test_empty_scope_contains_returns_empty(self):
+        answers = {**FULL_ANSWERS_MANAGE, "scope_contains": []}
+        result = config.build_secret_key_names(answers, "aws")
+        self.assertEqual(result, {})
+
+    def test_locked_entry_uses_answered_key(self):
+        answers = {
+            **FULL_ANSWERS_MANAGE,
+            "scope_contains": ["client_secret"],
+            "key_name__client_secret": "my-sp-secret",
+        }
+        result = config.build_secret_key_names(answers, "aws")
+        self.assertEqual(result["client_secret"], "my-sp-secret")
+
+    def test_default_key_used_when_no_override(self):
+        answers = {
+            **FULL_ANSWERS_MANAGE,
+            "scope_contains": ["client_secret"],
+            # no key_name__client_secret
+        }
+        result = config.build_secret_key_names(answers, "aws")
+        self.assertEqual(result["client_secret"], "client-secret")
+
+    def test_multiple_selections(self):
+        answers = {
+            **FULL_ANSWERS_BYO,
+            "scope_contains": ["client_secret", "account_id", "client_id"],
+            "key_name__client_secret": "sp-secret",
+            "key_name__account_id": "acct-id",
+            "key_name__client_id": "sp-app-id",
+        }
+        result = config.build_secret_key_names(answers, "aws")
+        self.assertEqual(result["client_secret"], "sp-secret")
+        self.assertEqual(result["account_id"], "acct-id")
+        self.assertEqual(result["client_id"], "sp-app-id")
+
+    def test_azure_only_keys_excluded_on_aws(self):
+        answers = {
+            **FULL_ANSWERS_MANAGE,
+            "scope_contains": ["client_secret", "tenant_id"],
+        }
+        result = config.build_secret_key_names(answers, "aws")
+        # tenant_id is azure-only; must not appear for an AWS cloud
+        self.assertNotIn("tenant_id", result)
+
+    def test_azure_only_keys_included_on_azure(self):
+        answers = {
+            **FULL_ANSWERS_MANAGE,
+            "scope_contains": ["client_secret", "tenant_id", "subscription_id"],
+            "key_name__tenant_id": "my-tenant",
+            "key_name__subscription_id": "my-sub",
+        }
+        result = config.build_secret_key_names(answers, "azure")
+        self.assertEqual(result["tenant_id"], "my-tenant")
+        self.assertEqual(result["subscription_id"], "my-sub")
+
+
+class TestAnalysisSchemaDeferral(unittest.TestCase):
+    """analysis_schema_name in scope_contains suppresses catalog/schema prompts
+    and prevents ensure_app_config_secrets from writing to the scope.
+    """
+
+    def test_analysis_schema_name_in_checkbox_choices(self):
+        """analysis_schema_name must appear as a deferrable option."""
+        questions = _build()
+        cb = next(q for q in questions if q.name == "scope_contains")
+        # choices is list of (label, logical) tuples
+        logicals = [v for _, v in (cb.choices or [])]
+        self.assertIn(
+            "analysis_schema_name", logicals,
+            "analysis_schema_name must be a checkbox option so users can defer it"
+        )
+
+    def test_catalog_hidden_when_schema_deferred(self):
+        questions = {q.name: q for q in _build()}
+        q = questions["catalog"]
+        answers = {**FULL_ANSWERS_BYO, "scope_contains": ["client_secret", "analysis_schema_name"]}
+        self.assertTrue(
+            _eval_ignore(q, answers),
+            "catalog prompt should be hidden when analysis_schema_name is deferred"
+        )
+
+    def test_catalog_shown_when_schema_not_deferred(self):
+        questions = {q.name: q for q in _build()}
+        q = questions["catalog"]
+        answers = {**FULL_ANSWERS_BYO, "scope_contains": ["client_secret"]}
+        self.assertFalse(
+            _eval_ignore(q, answers),
+            "catalog prompt should be shown when analysis_schema_name is not deferred"
+        )
+
+    def test_schema_prompt_hidden_when_deferred(self):
+        questions = {q.name: q for q in _build()}
+        q = questions["security_analysis_schema"]
+        answers = {**FULL_ANSWERS_BYO, "scope_contains": ["client_secret", "analysis_schema_name"]}
+        self.assertTrue(_eval_ignore(q, answers))
+
+    def test_schema_prompt_shown_when_not_deferred(self):
+        questions = {q.name: q for q in _build()}
+        q = questions["security_analysis_schema"]
+        answers = {**FULL_ANSWERS_MANAGE, "scope_contains": []}
+        self.assertFalse(_eval_ignore(q, answers))
+
+    def test_resolve_app_config_scope_schema_deferred_returns_credential_scope(self):
+        """When analysis_schema_name is in scope_contains the app binds to the
+        credential scope directly — no sat_app_scope created.
+        """
+        answers = {
+            "app_config_scope": "",
+            "scope_contains": ["client_secret", "analysis_schema_name"],
+        }
+        result = config._resolve_app_config_scope(answers, "my-vault-scope", manage_secrets=False)
+        self.assertEqual(
+            result, "my-vault-scope",
+            "Should return the credential scope, not sat_app_scope"
+        )
+
+    def test_resolve_app_config_scope_schema_not_deferred_byo_returns_sat_app_scope(self):
+        """When analysis_schema_name is NOT deferred and manage_secrets=False,
+        sat_app_scope is still the fallback."""
+        answers = {
+            "app_config_scope": "",
+            "scope_contains": ["client_secret"],
+        }
+        result = config._resolve_app_config_scope(answers, "my-vault-scope", manage_secrets=False)
+        self.assertEqual(result, "sat_app_scope")
+
+    def test_ensure_app_config_skips_write_when_schema_deferred(self):
+        """ensure_app_config_secrets must not call put_secret when
+        analysis_schema_name is in scope_contains."""
+        client = MagicMock()
+        client.secrets.list_scopes.return_value = []
+        answers = {
+            **FULL_ANSWERS_BYO,
+            "enable_brickhound": True,
+            "scope_contains": ["client_secret", "analysis_schema_name"],
+        }
+        config.ensure_app_config_secrets(
+            client, answers, "my-vault-scope", False, {}, set()
+        )
+        client.secrets.put_secret.assert_not_called()
+        client.secrets.create_scope.assert_not_called()
+
+    def test_ensure_app_config_writes_when_schema_not_deferred(self):
+        """ensure_app_config_secrets must write when analysis_schema_name
+        is not in scope_contains."""
+        client = MagicMock()
+        answers = {
+            **FULL_ANSWERS_MANAGE,
+            "enable_brickhound": True,
+            "scope_contains": ["client_secret"],
+            "catalog": "main",
+            "security_analysis_schema": "security_analysis",
+        }
+        existing = {"sat_scope"}
+        config.ensure_app_config_secrets(
+            client, answers, "sat_scope", True, {}, existing
+        )
+        client.secrets.put_secret.assert_called_once()
+        call_kwargs = client.secrets.put_secret.call_args
+        self.assertEqual(call_kwargs.kwargs.get("key") or call_kwargs[1].get("key"),
+                         "analysis_schema_name")
+
+
+class TestResolveKeyOverrides(unittest.TestCase):
+    """_resolve_key_overrides: blank / structured / JSON / bad."""
+
+    def test_blank_returns_empty(self):
+        self.assertEqual(config._resolve_key_overrides({"secret_key_names": ""}), {})
+
+    def test_missing_key_returns_empty(self):
+        self.assertEqual(config._resolve_key_overrides({}), {})
+
+    def test_structured_dict_wins(self):
+        answers = {
+            "secret_key_names_dict": {"client_secret": "my-secret"},
+            "secret_key_names": '{"client_secret": "wrong"}',
+        }
+        self.assertEqual(
+            config._resolve_key_overrides(answers),
+            {"client_secret": "my-secret"}
+        )
+
+    def test_legacy_json_string_parsed(self):
+        answers = {"secret_key_names": '{"client_secret": "my-sp-secret"}'}
+        self.assertEqual(
+            config._resolve_key_overrides(answers),
+            {"client_secret": "my-sp-secret"}
+        )
+
+    def test_invalid_json_returns_empty(self):
+        self.assertEqual(
+            config._resolve_key_overrides({"secret_key_names": "not-json"}),
+            {}
+        )
+
+
+class TestResolveAppConfigScope(unittest.TestCase):
+
+    def _a(self, app_config_scope=""):
+        return {"app_config_scope": app_config_scope}
+
+    def test_explicit_name_wins(self):
+        self.assertEqual(
+            config._resolve_app_config_scope(self._a("my-app-scope"), "sat_scope", False),
+            "my-app-scope",
+        )
+
+    def test_manage_true_falls_back_to_main_scope(self):
+        self.assertEqual(
+            config._resolve_app_config_scope(self._a(), "sat_scope", True),
+            "sat_scope",
+        )
+
+    def test_manage_false_falls_back_to_sat_app_scope(self):
+        self.assertEqual(
+            config._resolve_app_config_scope(self._a(), "sat_scope", False),
+            "sat_app_scope",
+        )
+
+
+class TestValidateSecrets(unittest.TestCase):
+    """A4: validate_secrets uses scope= key= signature; reports all missing at once."""
+
+    def _make_client(self, secret_value="s3cr3t", scope_names=None):
+        client = MagicMock()
+        scope = MagicMock()
+        scope.name = scope_names[0] if scope_names else "my-scope"
+        client.secrets.list_scopes.return_value = [scope]
+        secret_resp = MagicMock()
+        secret_resp.value = secret_value
+        client.secrets.get_secret.return_value = secret_resp
+        return client
+
+    def _byo_answers(self, scope="my-scope", key="client-secret", scope_contains=None):
+        return {
+            "secret_scope": scope,
+            "secret_key_names_dict": (
+                {"client_secret": key} if key != "client-secret" else {}
+            ),
+            "scope_contains": scope_contains or ["client_secret"],
+            "enable_brickhound": False,
+        }
+
+    def test_uses_scope_and_key_kwargs(self):
+        """Must call get_secret(scope=..., key=...) not get_secret(path=...)."""
+        client = self._make_client()
+        config.validate_secrets(client, self._byo_answers(), "aws")
+        client.secrets.get_secret.assert_called_once_with(
+            scope="my-scope", key="client-secret"
+        )
+
+    def test_key_override_respected(self):
+        client = self._make_client()
+        config.validate_secrets(
+            client, self._byo_answers(key="my-custom-key"), "aws"
+        )
+        client.secrets.get_secret.assert_called_once_with(
+            scope="my-scope", key="my-custom-key"
+        )
+
+    def test_missing_scope_raises(self):
+        client = MagicMock()
+        client.secrets.list_scopes.return_value = []
+        with self.assertRaises(ValueError) as ctx:
+            config.validate_secrets(
+                client, self._byo_answers(scope="nonexistent"), "aws"
+            )
+        self.assertIn("nonexistent", str(ctx.exception))
+
+    def test_missing_secret_raises(self):
+        client = self._make_client()
+        client.secrets.get_secret.side_effect = Exception("secret not found")
+        with self.assertRaises(ValueError) as ctx:
+            config.validate_secrets(client, self._byo_answers(), "aws")
+        self.assertIn("client_secret", str(ctx.exception))
+
+    def test_reports_all_missing_at_once(self):
+        """Both missing keys must appear in a single error message."""
+        client = MagicMock()
+        scope = MagicMock(); scope.name = "my-scope"
+        client.secrets.list_scopes.return_value = [scope]
+        client.secrets.get_secret.side_effect = Exception("not found")
+
+        answers = self._byo_answers(
+            scope_contains=["client_secret", "account_id"]
+        )
+        with self.assertRaises(ValueError) as ctx:
+            config.validate_secrets(client, answers, "aws")
+        msg = str(ctx.exception)
+        self.assertIn("client_secret", msg)
+        self.assertIn("account_id", msg)
+
+    def test_empty_scope_contains_still_validates_client_secret(self):
+        """scope_contains=[] is treated as ['client_secret'] because client_secret
+        is locked — it is always in the scope on the BYO path.  validate_secrets
+        must still check it is readable even when the list is otherwise empty."""
+        client = self._make_client()
+        answers = self._byo_answers(scope_contains=[])
+        # scope_contains=[] → resolves to ["client_secret"] via `or` default
+        config.validate_secrets(client, answers, "aws")
+        client.secrets.get_secret.assert_called_once_with(
+            scope="my-scope", key="client-secret"
+        )
+
+
+class TestPromptFlowSimulation(unittest.TestCase):
+    """Simulate the actual inquirer render loop to catch wiring bugs.
+
+    Previous crashes were caused by unit-testing pure helper functions with
+    synthetic inputs that couldn't occur in the real flow.  This class models
+    what ConsoleRender.render() actually does:
+
+        if question.ignore:
+            answers[q.name] = question.default  # stored even when hidden
+        else:
+            answers[q.name] = user_input        # or default if user presses Enter
+
+    For each scenario the "user" accepts every pre-filled default (presses Enter
+    on every shown prompt), mirroring the exact behaviour that caused the
+    sat_app_scope 404 crash.
+
+    The key assertion in every case: the final _resolve_app_config_scope()
+    output must be a scope that SAT actually wrote to or that the user pre-populated
+    — never a scope that was neither created nor written.
+    """
+
+    # Warehouse sentinel — all scenarios have a warehouse.
+    _WH = {"id": "abcd1234abcd1234", "name": "SAT WH"}
+
+    def _simulate(self, user_inputs: dict) -> dict:
+        """Walk build_questions() in order, populating answers the way
+        inquirer does: store default for hidden questions, user_input for shown.
+
+        user_inputs: {question_name: value} for questions where the simulated
+        user would type something other than the default.  Every other shown
+        question resolves to its default.
+        """
+        questions = _build()
+        answers = {}
+        for q in questions:
+            ignored = _eval_ignore(q, answers)
+            default = _eval_default(q, answers)
+            if ignored:
+                # inquirer stores the default even for ignored questions.
+                answers[q.name] = default
+            elif q.name in user_inputs:
+                answers[q.name] = user_inputs[q.name]
+            else:
+                # User pressed Enter — accept the pre-filled default.
+                answers[q.name] = default if default is not None else ""
+        return answers
+
+    # -----------------------------------------------------------------------
+    # Scenario 1: managed install, press Enter on everything
+    # -----------------------------------------------------------------------
+    def test_managed_install_accept_all_defaults(self):
+        """Regression: app_config_scope default must be '' for managed installs
+        so _resolve_app_config_scope returns the main scope, not sat_app_scope."""
+        answers = self._simulate({
+            "account_id": "12345678-1234-1234-1234-123456789abc",
+            "catalog": "main",
+            "warehouse": self._WH,
+            "aws-client-id": "sp-client-id",
+            "aws-client-secret": "sp-secret",
+        })
+        scope = config._resolve_app_config_scope(answers, "sat_scope", True)
+        self.assertEqual(scope, "sat_scope",
+                         "Managed install must use main scope, not sat_app_scope")
+
+    # -----------------------------------------------------------------------
+    # Scenario 2: BYO scope, no BrickHound
+    # -----------------------------------------------------------------------
+    def test_byo_no_brickhound_no_app_scope_prompt(self):
+        """No BrickHound → app_config_scope prompt hidden → scope irrelevant."""
+        answers = self._simulate({
+            "account_id": "12345678-1234-1234-1234-123456789abc",
+            "catalog": "main",
+            "warehouse": self._WH,
+            "secret_scope": "key-vault-secrets",
+            "manage_secrets": False,
+            "scope_contains": ["client_secret"],
+            "enable_brickhound": False,
+        })
+        # prompt must be hidden
+        q = {q.name: q for q in _build()}["app_config_scope"]
+        self.assertTrue(_eval_ignore(q, answers))
+
+    # -----------------------------------------------------------------------
+    # Scenario 3: BYO scope, analysis_schema_name deferred, user presses Enter
+    # (THE CRASH SCENARIO — user accepted the pre-filled "sat_app_scope" default)
+    # -----------------------------------------------------------------------
+    def test_byo_schema_deferred_enter_on_prompt_gives_credential_scope(self):
+        """When analysis_schema_name is in scope_contains the prompt must be
+        hidden — pressing Enter must not route the app binding to sat_app_scope."""
+        answers = self._simulate({
+            "account_id": "12345678-1234-1234-1234-123456789abc",
+            "catalog": "main",          # skipped by ignore but kept in inputs
+            "warehouse": self._WH,
+            "secret_scope": "key-vault-secrets",
+            "manage_secrets": False,
+            "scope_contains": ["client_secret", "analysis_schema_name"],
+            "key_name__analysis_schema_name": "sat-analysis-schema-name",
+            "enable_brickhound": True,
+            # Deliberately do NOT supply app_config_scope — the simulation
+            # will store the default the same way inquirer does.
+        })
+        # 1. The prompt must be hidden.
+        q = {q.name: q for q in _build()}["app_config_scope"]
+        self.assertTrue(
+            _eval_ignore(q, answers),
+            "app_config_scope prompt must be hidden when schema is deferred"
+        )
+        # 2. The stored default must be blank (not "sat_app_scope").
+        self.assertEqual(
+            answers.get("app_config_scope"), "",
+            f"app_config_scope stored as {answers.get('app_config_scope')!r}; "
+            f"must be '' when prompt is hidden"
+        )
+        # 3. The resolved scope must be the credential scope, not sat_app_scope.
+        scope = config._resolve_app_config_scope(answers, "key-vault-secrets", False)
+        self.assertEqual(
+            scope, "key-vault-secrets",
+            f"App should bind to credential scope; got {scope!r}"
+        )
+        # 4. ensure_app_config_secrets must not write or create anything.
+        client = MagicMock()
+        config.ensure_app_config_secrets(
+            client, answers, "key-vault-secrets", False, {}, {"key-vault-secrets"}
+        )
+        client.secrets.put_secret.assert_not_called()
+        client.secrets.create_scope.assert_not_called()
+
+    # -----------------------------------------------------------------------
+    # Scenario 4: BYO scope, schema NOT deferred, user accepts sat_app_scope
+    # -----------------------------------------------------------------------
+    def test_byo_schema_not_deferred_enter_gives_sat_app_scope(self):
+        """When schema is not deferred, sat_app_scope must be both shown and
+        used as the write target — the scope SAT creates."""
+        answers = self._simulate({
+            "account_id": "12345678-1234-1234-1234-123456789abc",
+            "catalog": "main",
+            "security_analysis_schema": "security_analysis",
+            "warehouse": self._WH,
+            "secret_scope": "key-vault-secrets",
+            "manage_secrets": False,
+            "scope_contains": ["client_secret"],  # schema NOT deferred
+            "enable_brickhound": True,
+            # Accept the pre-filled default for app_config_scope.
+        })
+        # 1. Prompt must be shown.
+        q = {q.name: q for q in _build()}["app_config_scope"]
+        self.assertFalse(
+            _eval_ignore(q, answers),
+            "app_config_scope prompt must be shown when schema is not deferred"
+        )
+        # 2. The resolved scope must be sat_app_scope (user pressed Enter).
+        scope = config._resolve_app_config_scope(answers, "key-vault-secrets", False)
+        self.assertEqual(scope, "sat_app_scope")
+
+    # -----------------------------------------------------------------------
+    # Scenario 5: BYO scope, schema NOT deferred, user types custom scope
+    # -----------------------------------------------------------------------
+    def test_byo_schema_not_deferred_custom_scope_respected(self):
+        """Explicit non-default app_config_scope must be honoured."""
+        answers = self._simulate({
+            "account_id": "12345678-1234-1234-1234-123456789abc",
+            "catalog": "main",
+            "security_analysis_schema": "security_analysis",
+            "warehouse": self._WH,
+            "secret_scope": "key-vault-secrets",
+            "manage_secrets": False,
+            "scope_contains": ["client_secret"],
+            "enable_brickhound": True,
+            "app_config_scope": "my-app-config-scope",
+        })
+        scope = config._resolve_app_config_scope(answers, "key-vault-secrets", False)
+        self.assertEqual(scope, "my-app-config-scope")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dabs/tests/test_notebook_params.py
+++ b/dabs/tests/test_notebook_params.py
@@ -1,0 +1,199 @@
+"""
+Drift guards for SAT notebook parameter forwarding.
+
+These tests run offline (no Databricks workspace needed) and catch two
+classes of bug that have each shipped once:
+
+1. A widget added to initialize.py without a matching key in SAT_CHILD_PARAMS
+   → child notebooks spawned via dbutils.notebook.run() silently miss the value.
+
+2. A base_parameters block in a DABS .yml.tmpl that is missing one or more of
+   the 10 required SAT widget names → the child's initialize.py falls back to
+   scope reads that fail for installs where values travel as job parameters.
+"""
+import re
+import sys
+import unittest
+from pathlib import Path
+
+_ROOT = Path(__file__).parent.parent.parent  # repo root
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _read(rel: str) -> str:
+    return (_ROOT / rel).read_text()
+
+
+def _widget_names_from_initialize() -> set:
+    """Extract every name declared by dbutils.widgets.text("name", ...) in initialize.py."""
+    src = _read("notebooks/Utils/initialize.py")
+    return set(re.findall(r'dbutils\.widgets\.text\(\s*["\']([^"\']+)["\']', src))
+
+
+def _child_param_keys_from_initialize() -> set:
+    """Extract the dict keys declared in SAT_CHILD_PARAMS = { ... }.
+
+    Uses a simple brace-counter rather than [^}]+ to handle nested braces
+    in values like json.dumps(...) if _key_overrides else "{}".
+    """
+    src = _read("notebooks/Utils/initialize.py")
+    start = src.find("SAT_CHILD_PARAMS")
+    if start == -1:
+        return set()
+    brace_start = src.find("{", start)
+    if brace_start == -1:
+        return set()
+    depth, i = 0, brace_start
+    while i < len(src):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                break
+        i += 1
+    block_text = src[brace_start + 1:i]
+    return set(re.findall(r'"([^"]+)"\s*:', block_text))
+
+
+def _base_param_keys_from_tmpl(path: str) -> list[set]:
+    """Return a list of key-sets, one per base_parameters block in the file."""
+    src = _read(path)
+    blocks = []
+    # Split on base_parameters: then grab all key: value lines until a blank line
+    for match in re.finditer(r'base_parameters:\s*\n((?:[ \t]+\S[^\n]*\n)+)', src):
+        block_text = match.group(1)
+        keys = set(re.findall(r'[ \t]+([a-zA-Z_][a-zA-Z0-9_]*)\s*:', block_text))
+        blocks.append(keys)
+    return blocks
+
+
+# The 10 SAT widget names that every notebook_task's base_parameters must include.
+# Derived from the dbutils.widgets.text() declarations in initialize.py rather than
+# hardcoded so the test stays in sync automatically.
+_REQUIRED_PARAMS = frozenset({
+    "secret_scope",
+    "secret_key_names",
+    "account_id_param",
+    "client_id_param",
+    "tenant_id_param",
+    "subscription_id_param",
+    "sql_warehouse_id_param",
+    "analysis_schema_name_param",
+    "proxies_param",
+    "use_sp_auth_param",
+})
+
+# DABS .yml.tmpl files that contain notebook_task blocks
+_TMPL_FILES = [
+    "dabs/dabs_template/template/tmp/resources/sat_initiliazer_job.yml.tmpl",
+    "dabs/dabs_template/template/tmp/resources/sat_driver_job.yml.tmpl",
+    "dabs/dabs_template/template/tmp/resources/sat_secrets_scanner_job.yml.tmpl",
+    "dabs/dabs_template/template/tmp/resources/brickhound_job.yml.tmpl",
+]
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+class TestSatChildParamsCoversAllWidgets(unittest.TestCase):
+    """Every widget declared in initialize.py must have a matching key in
+    SAT_CHILD_PARAMS, otherwise child notebooks spawned via
+    dbutils.notebook.run() silently miss the value.
+    """
+
+    def test_child_params_covers_all_widgets(self):
+        widgets = _widget_names_from_initialize()
+        self.assertTrue(widgets, "No widgets found in initialize.py — regex broken?")
+
+        child_keys = _child_param_keys_from_initialize()
+        self.assertTrue(child_keys, "SAT_CHILD_PARAMS not found in initialize.py")
+
+        missing = widgets - child_keys
+        self.assertFalse(
+            missing,
+            f"Widgets declared in initialize.py but missing from SAT_CHILD_PARAMS:\n"
+            + "\n".join(f"  {k}" for k in sorted(missing))
+            + "\nAdd them so child notebooks receive the value."
+        )
+
+    def test_no_extra_unknown_keys_in_child_params(self):
+        """SAT_CHILD_PARAMS should not contain keys that aren't widget names
+        (guards against typos in the key names)."""
+        widgets = _widget_names_from_initialize()
+        child_keys = _child_param_keys_from_initialize()
+        extra = child_keys - widgets
+        self.assertFalse(
+            extra,
+            f"Keys in SAT_CHILD_PARAMS that are not widget names in initialize.py:\n"
+            + "\n".join(f"  {k}" for k in sorted(extra))
+            + "\nEither add the widget or remove the key."
+        )
+
+
+class TestRunNotebookForwardsChildParams(unittest.TestCase):
+    """security_analysis_initializer.py's run_notebook() must reference
+    SAT_CHILD_PARAMS so children receive the full widget context.
+    """
+
+    def test_run_notebook_passes_sat_child_params(self):
+        src = _read("notebooks/security_analysis_initializer.py")
+        # Find the run_notebook function body
+        fn = re.search(
+            r'def run_notebook\(.*?\):(.*?)(?=\ndef |\Z)', src, re.DOTALL
+        )
+        self.assertIsNotNone(fn, "run_notebook function not found")
+        body = fn.group(1)
+        self.assertIn(
+            "SAT_CHILD_PARAMS", body,
+            "run_notebook() must pass SAT_CHILD_PARAMS to dbutils.notebook.run(). "
+            "Without it, child notebooks' initialize.py falls back to scope reads "
+            "that fail for installs where values travel as job parameters."
+        )
+
+
+class TestAllTmplTasksHaveFullParamSet(unittest.TestCase):
+    """Every base_parameters block in every DABS .yml.tmpl must contain all
+    10 required SAT widget names.  Task-specific extras are allowed.
+    """
+
+    def test_required_widget_names_consistent_with_initialize(self):
+        """The _REQUIRED_PARAMS constant in this test must match the actual
+        widget names in initialize.py."""
+        widgets = _widget_names_from_initialize()
+        missing_from_test = widgets - _REQUIRED_PARAMS
+        self.assertFalse(
+            missing_from_test,
+            f"Widgets in initialize.py not in _REQUIRED_PARAMS test constant:\n"
+            + "\n".join(f"  {k}" for k in sorted(missing_from_test))
+            + "\nUpdate _REQUIRED_PARAMS in this test file."
+        )
+
+    def test_all_notebook_tasks_pass_full_param_set(self):
+        failures = []
+        for tmpl in _TMPL_FILES:
+            blocks = _base_param_keys_from_tmpl(tmpl)
+            if not blocks:
+                failures.append(f"{tmpl}: no base_parameters blocks found")
+                continue
+            for i, keys in enumerate(blocks):
+                missing = _REQUIRED_PARAMS - keys
+                if missing:
+                    failures.append(
+                        f"{tmpl} block #{i+1} missing: {', '.join(sorted(missing))}"
+                    )
+        self.assertFalse(
+            failures,
+            "base_parameters blocks missing required SAT widget names:\n"
+            + "\n".join(f"  {f}" for f in failures)
+            + "\nEvery notebook_task must forward all SAT widget names so "
+            "initialize.py can populate its widgets in the child context."
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/sat/docs/faq.mdx
+++ b/docs/sat/docs/faq.mdx
@@ -125,4 +125,35 @@ There are a few checks that rely on self-assessment due to the lack of REST APIs
 
 </AccordionItem>
 
+<AccordionItem question="Can I use my own secret scope and key names?">
+
+Yes. SAT only requires the service principal **client secret** to live in a Databricks secret scope — everything else (Account ID, Client ID, SQL Warehouse ID, schema name, etc.) is passed as a direct job parameter in version 0.9+.
+
+**Standard install (`install.sh`):**
+
+1. At the *"Secret scope name"* prompt, enter your existing scope name.
+2. At *"Let SAT write the service principal secret to this scope?"*, answer **No**.
+3. A checkbox lists the values SAT can read from your scope — select each one that is pre-populated.
+4. For each selected value, confirm or change the physical key name used in your scope.
+
+**Terraform install:**
+
+```hcl
+manage_secrets      = false
+secret_scope_name   = "my-corp-scope"
+scope_provided_keys = ["client_secret", "analysis_schema_name"]
+
+# Override key names if yours differ from SAT defaults
+secret_key_names = {
+  client_secret        = "sat-sp-secret"
+  analysis_schema_name = "sat-analysis-schema"
+}
+```
+
+**Azure Key Vault-backed scopes** are supported with `manage_secrets = false` because SAT will not call `put-acl` or `put_secret`. Grant the SAT service principal **Key Vault Secrets User** in Azure RBAC to allow it to read the secret values.
+
+See the [Secret Scope Reference](./installation/secret-scope.mdx) for the full key list, per-cloud requirements, and the app config scope options.
+
+</AccordionItem>
+
 ---

--- a/docs/sat/docs/installation/index.mdx
+++ b/docs/sat/docs/installation/index.mdx
@@ -50,6 +50,8 @@ Before proceeding with the installation, make sure you have the following prereq
 - Databricks SQL Warehouse (To run the SQL dashboard)
 - PyPI access from your workspace (To install the SAT utility library)
 
+**Optional — bring your own secret scope:** SAT defaults to creating a `sat_scope` secret scope and writing a single secret (the service principal client secret). If you already have a secret scope you would prefer SAT to read from — including Azure Key Vault-backed scopes — see [Secret Scope Reference](./secret-scope.mdx) for how to configure this during installation.
+
 
 
 

--- a/docs/sat/docs/installation/secret-scope.mdx
+++ b/docs/sat/docs/installation/secret-scope.mdx
@@ -1,0 +1,153 @@
+---
+sidebar_label: Secret Scope Reference
+---
+
+import Admonition from '@theme/Admonition';
+
+# Secret Scope Reference
+
+SAT stores credentials in a Databricks secret scope. Starting in version 0.9, most
+configuration values (Account ID, Client ID, SQL Warehouse ID, etc.) are passed as
+direct job parameters instead of secrets — only the **service principal client secret**
+must live in the scope because it is an actual credential.
+
+This page describes the scope contract, what keys are required, and how to bring your
+own pre-existing scope.
+
+---
+
+## What must be in the scope
+
+| Logical name | Default physical key | Required | Notes |
+|---|---|---|---|
+| `client_secret` | `client-secret` | **Always** | SP OAuth secret — the only true credential |
+| `workspace_pat_token_prefix` | `sat-token` | Only when `use_mastercreds=false` | Dormant in standard installs |
+
+All other values are passed as direct job `base_parameters` for 0.9+ installs. For
+**backward compatibility**, SAT also falls back to reading them from the scope (at the
+physical key names below) so that 0.8.x installs continue to work unchanged.
+
+Additionally, `analysis_schema_name` may optionally come from your scope — see
+[BrickHound app config scope](#brickhound-app-config-scope) below.
+
+| Logical name | Default physical key | Cloud(s) | Notes |
+|---|---|---|---|
+| `account_id` | `account-console-id` | All | |
+| `sql_warehouse_id` | `sql-warehouse-id` | All | Notebook fallback only; app reads from `sql_warehouse` resource |
+| `analysis_schema_name` | `analysis_schema_name` | All | Required for BrickHound app; can be pre-populated in your scope |
+| `proxies` | `proxies` | All (JSON, e.g. `{}`) | |
+| `use_sp_auth` | `use-sp-auth` | AWS, GCP | |
+| `client_id` | `client-id` | All | |
+| `tenant_id` | `tenant-id` | Azure | |
+| `subscription_id` | `subscription-id` | Azure | |
+
+---
+
+## Default scope name
+
+`sat_scope` — override via `secret_scope_name` (Terraform) or the `secret_scope`
+installer prompt (standard `install.sh`).
+
+---
+
+## Bringing your own scope
+
+### Terraform
+
+```hcl
+# terraform.tfvars
+manage_secrets    = false          # SAT will not create the scope or write any keys
+secret_scope_name = "my-corp-scope"
+
+# Override key names if yours differ from SAT defaults
+# secret_key_names = {
+#   client_secret        = "sat-sp-secret"
+#   analysis_schema_name = "sat-analysis-schema"   # if pre-populated in your scope
+# }
+
+# Declare which keys are already in your scope so SAT skips writing them
+# and the BrickHound app binding points at your scope directly.
+# scope_provided_keys = ["client_secret", "analysis_schema_name"]
+```
+
+When `manage_secrets = false`, `terraform apply` validates that all keys in
+`scope_provided_keys` are readable before proceeding.
+
+### Standard install (`install.sh`)
+
+The installer prompts:
+
+1. **Secret scope name** — enter your existing scope name (default: `sat_scope`)
+2. **Let SAT write the service principal secret to this scope?** — answer **No**
+3. **Which values are already in your scope?** — checkbox; select everything present, including `analysis_schema_name` if applicable
+4. **Secret scope key name for: ...** — one prompt per selected item to confirm or change the physical key name
+
+The installer validates all declared keys are readable before bundle deploy.
+
+---
+
+## BrickHound app config scope
+
+The Databricks App powering the Permissions Analysis UI needs `analysis_schema_name`
+via [`valueFrom`](https://docs.databricks.com/en/dev-tools/databricks-apps/app-development.html#resource-types)
+to set the `BRICKHOUND_SCHEMA` env var. `WAREHOUSE_ID` no longer needs a secret — it
+resolves from the `sql_warehouse` resource directly.
+
+### When SAT manages your secrets (default)
+
+`analysis_schema_name` is written to `secret_scope_name`. No extra config needed.
+
+### When you bring your own scope
+
+| Scenario | What happens |
+|---|---|
+| `analysis_schema_name` in `scope_provided_keys` / checkbox | App binds to your scope directly. SAT writes nothing. No `sat_app_scope` created. |
+| `analysis_schema_name` **not** in `scope_provided_keys`, `app_config_scope_name` = `""` | SAT creates `sat_app_scope` and writes the key there. Your credential scope is untouched. |
+| `analysis_schema_name` **not** in `scope_provided_keys`, `app_config_scope_name` = `"my-app-scope"` | SAT writes to the scope you specified. |
+
+Set `app_config_scope_name` in `terraform.tfvars` or at the `install.sh` prompt (shown
+when BrickHound is enabled and `manage_secrets = false`).
+
+<Admonition type="note">
+`manage_secrets = false` means SAT writes nothing to your credential scope.
+When `analysis_schema_name` is pre-populated there, the app reads it directly and
+no separate app config scope is created. The clean opt-out from all of this is
+disabling BrickHound.
+</Admonition>
+
+---
+
+## Required ACLs
+
+The SAT service principal needs **READ** permission on the scope it reads from.
+
+For **Databricks-backed scopes** (default), set the ACL via:
+
+```bash
+databricks secrets put-acl --scope my-corp-scope \
+  --principal "service-principals/<app-id>" --permission READ
+```
+
+For **Azure Key Vault-backed scopes**, ACLs are managed through Azure RBAC — grant the
+SAT service principal **Key Vault Secrets User** on the vault. You cannot call
+`put-acl` on these scopes via the Databricks API, so `manage_secrets` must be `false`.
+
+<Admonition type="caution">
+Whether Databricks Apps can auto-create the READ ACL it needs on an Azure Key Vault-backed
+scope is not confirmed by official documentation. Scope ACLs are Databricks-side (the Key
+Vault backing only governs secret values), so it should work — but verify in your
+environment before relying on it.
+</Admonition>
+
+---
+
+## Key name resolution order
+
+For each non-secret config value, SAT resolves in this order at notebook runtime:
+
+1. **Job `base_parameter` / widget** (non-empty) → used immediately
+2. **Secret scope** at the configured physical key → legacy fallback, keeps 0.8.x installs working
+3. **Safe default** where one exists (`proxies` → `{}`, `use_sp_auth` → `false`)
+4. **Hard failure** — error names the value, the scope, and the physical key
+
+`client_secret` skips steps 1 and 3 — it is always read from the scope.

--- a/docs/sat/docs/installation/standard/aws.mdx
+++ b/docs/sat/docs/installation/standard/aws.mdx
@@ -111,6 +111,36 @@ The installation script will guide you through the setup process. Here's what it
   <img src={useBaseUrl('/gif/terminal-aws.gif')} alt="Installation Process" />
 </div>
 
+<Admonition type="note" title="Note: recording predates BYO-scope prompts">
+The GIF above was recorded before version 0.9. The current installer asks for
+`secret_scope` and whether SAT should manage secrets **before** the credential
+prompts. See the full prompt sequence below.
+</Admonition>
+
+<details>
+<summary>Full prompt walkthrough (0.9+)</summary>
+
+| Prompt | Default | Notes |
+|---|---|---|
+| Select profile | — | Databricks CLI profile |
+| Secret scope name | `sat_scope` | Name of the scope SAT reads from |
+| Let SAT write the service principal secret to this scope? | Yes | Answer **No** to bring your own pre-populated scope |
+| Which values are already in your scope? *(BYO only)* | `client_secret` locked | Checkbox — select any additional values already in your scope |
+| Secret scope key name for: ... *(BYO only)* | SAT default | One prompt per selected item to confirm/change the key name |
+| Databricks Account ID | — | Skipped when deferred to scope |
+| Select catalog | — | Skipped when `analysis_schema_name` is deferred |
+| Schema name for SAT | `security_analysis` | Skipped when `analysis_schema_name` is deferred |
+| Run on serverless? | Yes | |
+| Select warehouse | — | |
+| SAT service principal Client ID | — | Skipped when deferred to scope |
+| Want to use a proxy? | No | |
+| Driver / Secrets scanner schedules, timezone | — | |
+| Deploy Permissions Analysis? | Yes | |
+| Scope SAT will create for app config *(BYO + BrickHound only)* | `sat_app_scope` | Shown only when the schema is **not** already in your scope |
+
+For the BYO scope flow and Azure Key Vault-backed scopes, see the [Secret Scope Reference](../secret-scope.mdx).
+</details>
+
 ---
 
 <Admonition type="note" title="Permissions Analysis App Setup">

--- a/docs/sat/docs/installation/standard/azure.mdx
+++ b/docs/sat/docs/installation/standard/azure.mdx
@@ -156,6 +156,38 @@ The installation script will guide you through the setup process. Here's what it
   <img src={useBaseUrl('/gif/terminal-azure.gif')} alt="Installation Process" />
 </div>
 
+<Admonition type="note" title="Note: recording predates BYO-scope prompts">
+The GIF above was recorded before version 0.9. The current installer asks for
+`secret_scope` and whether SAT should manage secrets **before** the credential
+prompts. See the full prompt sequence below.
+</Admonition>
+
+<details>
+<summary>Full prompt walkthrough (0.9+)</summary>
+
+| Prompt | Default | Notes |
+|---|---|---|
+| Select profile | — | Databricks CLI profile |
+| Secret scope name | `sat_scope` | Name of the scope SAT reads from |
+| Let SAT write the service principal secret to this scope? | Yes | Answer **No** to bring your own pre-populated scope |
+| Which values are already in your scope? *(BYO only)* | `client_secret` locked | Checkbox — select any additional values already in your scope |
+| Secret scope key name for: ... *(BYO only)* | SAT default | One prompt per selected item |
+| Databricks Account ID | — | Skipped when deferred to scope |
+| Select catalog | — | Skipped when `analysis_schema_name` is deferred |
+| Schema name for SAT | `security_analysis` | Skipped when `analysis_schema_name` is deferred |
+| Run on serverless? | Yes | |
+| Select warehouse | — | |
+| Azure Tenant ID | — | Skipped when deferred |
+| Azure Subscription ID | — | Skipped when deferred |
+| SAT service principal Client ID | — | Skipped when deferred |
+| Want to use a proxy? | No | |
+| Driver / Secrets scanner schedules, timezone | — | |
+| Deploy Permissions Analysis? | Yes | |
+| Scope SAT will create for app config *(BYO + BrickHound only)* | `sat_app_scope` | Shown only when schema is not already in your scope |
+
+For the BYO scope flow and Azure Key Vault-backed scopes, see the [Secret Scope Reference](../secret-scope.mdx).
+</details>
+
 ---
 
 <Admonition type="note" title="Permissions Analysis App Setup">

--- a/docs/sat/docs/installation/standard/gcp.mdx
+++ b/docs/sat/docs/installation/standard/gcp.mdx
@@ -105,6 +105,36 @@ The installation script will guide you through the setup process. Here's what it
   <img src={useBaseUrl('/gif/terminal-aws.gif')} alt="Installation Process" />
 </div>
 
+<Admonition type="note" title="Note: recording predates BYO-scope prompts">
+The GIF above was recorded before version 0.9. The current installer asks for
+`secret_scope` and whether SAT should manage secrets **before** the credential
+prompts. See the full prompt sequence below.
+</Admonition>
+
+<details>
+<summary>Full prompt walkthrough (0.9+)</summary>
+
+| Prompt | Default | Notes |
+|---|---|---|
+| Select profile | — | Databricks CLI profile |
+| Secret scope name | `sat_scope` | Name of the scope SAT reads from |
+| Let SAT write the service principal secret to this scope? | Yes | Answer **No** to bring your own pre-populated scope |
+| Which values are already in your scope? *(BYO only)* | `client_secret` locked | Checkbox — select any additional values already in your scope |
+| Secret scope key name for: ... *(BYO only)* | SAT default | One prompt per selected item |
+| Databricks Account ID | — | Skipped when deferred to scope |
+| Select catalog | — | Skipped when `analysis_schema_name` is deferred |
+| Schema name for SAT | `security_analysis` | Skipped when `analysis_schema_name` is deferred |
+| Run on serverless? | Yes | |
+| Select warehouse | — | |
+| SAT service principal Client ID | — | Skipped when deferred |
+| Want to use a proxy? | No | |
+| Driver / Secrets scanner schedules, timezone | — | |
+| Deploy Permissions Analysis? | Yes | |
+| Scope SAT will create for app config *(BYO + BrickHound only)* | `sat_app_scope` | Shown only when schema is not already in your scope |
+
+For the BYO scope flow, see the [Secret Scope Reference](../secret-scope.mdx).
+</details>
+
 ---
 
 <Admonition type="note" title="Permissions Analysis App Setup">

--- a/docs/sat/docs/installation/terraform/aws.mdx
+++ b/docs/sat/docs/installation/terraform/aws.mdx
@@ -80,11 +80,24 @@ terraform apply
 
 ### Additional Considerations:
 
-If a pre-existing secret scope named `sat_scope` causes jobs to fail:
-1. Rename the secret scope in `secrets.tf`
-2. Re-run `terraform apply`.
-3. Update the secret scope name in 6 locations (`CMD 4` and `CMD 5`) of `Workspace -> Applications -> SAT-TF/notebooks/Utils/initialize`.
-4. Re-run failed jobs
+**Using a custom or pre-existing secret scope:**
+
+Set `secret_scope_name` in `terraform.tfvars` to use a different scope name (e.g. for multiple SAT instances):
+
+```hcl
+secret_scope_name = "sat_scope_prod"
+```
+
+To bring a pre-existing scope that you own and SAT should not write into, set `manage_secrets = false`. SAT will validate that the required `client-secret` key is readable and pass all other config as direct job parameters:
+
+```hcl
+manage_secrets = false
+secret_scope_name = "my-existing-scope"
+# Optional: override specific key names if yours differ from SAT defaults
+# secret_key_names = { client_secret = "my-sp-client-secret" }
+```
+
+See [Secret Scope Reference](../secret-scope.mdx) for the full list of required keys and ACL requirements.
 
 <Admonition type="note" title="Permissions Analysis App Setup">
 To set up the Permissions Analysis app and make it execute correctly, refer to the [Permissions Analysis Setup](./index.mdx#permissions-analysis-setup) section.

--- a/docs/sat/docs/installation/terraform/azure.mdx
+++ b/docs/sat/docs/installation/terraform/azure.mdx
@@ -97,11 +97,23 @@ terraform apply
 
 ### Additional Considerations:
 
-If a pre-existing secret scope named `sat_scope` causes jobs to fail:
-1. Rename the secret scope in `secrets.tf`
-2. Re-run `terraform apply`.
-3. Update the secret scope name in 6 locations (`CMD 4` and `CMD 5`) of `Workspace -> Applications -> SAT-TF/notebooks/Utils/initialize`.
-4. Re-run failed jobs
+**Using a custom or pre-existing secret scope:**
+
+Set `secret_scope_name` in `terraform.tfvars` to use a different scope name:
+
+```hcl
+secret_scope_name = "sat_scope_prod"
+```
+
+To bring a pre-existing scope, set `manage_secrets = false`:
+
+```hcl
+manage_secrets = false
+secret_scope_name = "my-existing-scope"
+# secret_key_names = { client_secret = "my-sp-client-secret" }
+```
+
+See [Secret Scope Reference](../secret-scope.mdx) for the full list of required keys and ACL requirements.
 
 <Admonition type="note" title="Permissions Analysis App Setup">
 To set up the Permissions Analysis app and make it execute correctly, refer to the [Permissions Analysis Setup](./index.mdx#permissions-analysis-setup) section.

--- a/docs/sat/docs/installation/terraform/gcp.mdx
+++ b/docs/sat/docs/installation/terraform/gcp.mdx
@@ -81,11 +81,23 @@ terraform apply
 
 ### Additional Considerations:
 
-If a pre-existing secret scope named `sat_scope` causes jobs to fail:
-1. Rename the secret scope in `secrets.tf`
-2. Re-run `terraform apply`.
-3. Update the secret scope name in 6 locations (`CMD 4` and `CMD 5`) of `Workspace -> Applications -> SAT-TF/notebooks/Utils/initialize`.
-4. Re-run failed jobs
+**Using a custom or pre-existing secret scope:**
+
+Set `secret_scope_name` in `terraform.tfvars` to use a different scope name:
+
+```hcl
+secret_scope_name = "sat_scope_prod"
+```
+
+To bring a pre-existing scope, set `manage_secrets = false`:
+
+```hcl
+manage_secrets = false
+secret_scope_name = "my-existing-scope"
+# secret_key_names = { client_secret = "my-sp-client-secret" }
+```
+
+See [Secret Scope Reference](../secret-scope.mdx) for the full list of required keys and ACL requirements.
 
 <Admonition type="note" title="Permissions Analysis App Setup">
 To set up the Permissions Analysis app and make it execute correctly, refer to the [Permissions Analysis Setup](./index.mdx#permissions-analysis-setup) section.

--- a/docs/sat/docs/installation/terraform/index.mdx
+++ b/docs/sat/docs/installation/terraform/index.mdx
@@ -56,7 +56,7 @@ To verify the configuration applied correctly, open **Compute → Apps → sat-p
 
 | Section | Expected entries |
 |---|---|
-| App resources | `warehouse` (SQL warehouse, Can use), `analysis_schema_name` (secret, Can read), `sql-warehouse-id` (secret, Can read) |
+| App resources | `warehouse` (SQL warehouse, Can use — also supplies `WAREHOUSE_ID` via `valueFrom`), `analysis_schema_name` (secret, Can read) |
 | User authorization | `sql` scope present |
 
 ### 3. Grant Unity Catalog permissions

--- a/docs/sat/docs/troubleshooting.mdx
+++ b/docs/sat/docs/troubleshooting.mdx
@@ -29,19 +29,41 @@ Diagnosis notebooks for each cloud platform are available to help troubleshoot y
 
 <AccordionItem question="Misconfigured Secrets - Secret does not exist with scope">
 
-**Error:**
+**Error (example):**
 
 ```
-Secret does not exist with scope: sat_scope and key: sat_tokens
+SAT configuration missing required value 'client_secret'.
+Expected as job parameter or secret scope 'my-scope' key 'client-secret'.
+```
+
+Or for 0.8.x installs:
+
+```
+Secret does not exist with scope: sat_scope and key: account-console-id
 ```
 
 **Resolution:**
 
-Check if the tokens are configured with the correct names by listing and comparing with the configuration.
+1. Check which scope SAT is configured to use. For 0.9+ installs this is the `secret_scope` job parameter; for older installs it is hardcoded to `sat_scope`.
 
-```bash
-databricks --profile e2-sat secrets list-secrets sat_scope
-```
+2. List the keys present in that scope:
+   ```bash
+   databricks secrets list-secrets <scope-name>
+   ```
+
+3. Verify the SAT service principal has READ permission:
+   ```bash
+   databricks secrets list-acls <scope-name>
+   ```
+
+4. For the full list of required keys per cloud, see the [Secret Scope Reference](./installation/secret-scope.mdx).
+
+**Azure Key Vault-backed scopes:** these scopes cannot be written to via the Databricks
+Secrets API, so `manage_secrets` must be `false`. Grant the SAT service principal
+**Key Vault Secrets User** in Azure RBAC instead of using `put-acl`.
+
+**Scope does not exist:** ensure the scope name matches exactly (case-sensitive) and
+the SAT service principal's token has access to list scopes.
 
 </AccordionItem>
 

--- a/docs/sat/docs/upgrade.mdx
+++ b/docs/sat/docs/upgrade.mdx
@@ -50,3 +50,37 @@ If you see fewer Identity & Access rows on Azure dashboards than before, this is
 - Run the diagnosis notebook for your cloud (`notebooks/diagnosis/sat_diagnosis_<cloud>.py`) — see [Troubleshooting](./troubleshooting.mdx).
 - Check the [Troubleshooting](./troubleshooting.mdx) page for entries on the Permissions Analysis consent banner, missing UC SELECT, and NS-14 expected behavior.
 - Open a [GitHub Issue](https://github.com/databricks-industry-solutions/security-analysis-tool/issues) if you hit something not covered.
+
+## Upgrading to 0.9.0
+
+### Permissions Analysis app — re-deploy required
+
+The BrickHound app (`sat-permissions-exp`) no longer uses a `sql-warehouse-id` secret
+resource. `WAREHOUSE_ID` now resolves from the existing `sql_warehouse` resource via
+`valueFrom: "warehouse"` in `app.yaml`, so the granted warehouse and the queried
+warehouse are always the same object.
+
+**Action required:** after upgrading, re-deploy the app to pick up the updated `app.yaml`:
+
+```bash
+# DABS install
+databricks apps deploy sat-permissions-exp \
+  --source-code-path /Workspace/Applications/SAT/files/app/brickhound
+
+# Terraform install
+terraform apply   # updates the app resource; then re-deploy manually or via CI
+```
+
+The orphaned `sql-warehouse-id` key in existing scopes is harmless — it will simply
+stop being read.
+
+### Secret scope: direct job parameters replace scope reads
+
+For 0.9.0+ installs, values such as `account-console-id`, `client-id`,
+`analysis_schema_name`, etc. are passed as direct job `base_parameters` rather than
+read from the scope at every run. The scope read still works as a fallback so existing
+0.8.x scopes continue to function unchanged — no migration is required unless you want
+to clean up the now-optional keys.
+
+See the [Secret Scope Reference](./installation/secret-scope.mdx) for the full key list
+and BYO-scope instructions.

--- a/docs/sat/sidebars.ts
+++ b/docs/sat/sidebars.ts
@@ -60,6 +60,7 @@ const sidebars = {
             'installation/terraform/gcp',
           ],
         },
+        'installation/secret-scope',
       ],
     },
     'upgrade',

--- a/notebooks/Utils/common.py
+++ b/notebooks/Utils/common.py
@@ -784,9 +784,130 @@ def process_json_schema(df):
 
 # COMMAND ----------
 
-# For testing
-JSONLOCALTESTA = '{"account_id": "", "sql_warehouse_id": "", "verbosity": "info", "master_name_scope": "sat_scope", "master_name_key": "user", "master_pwd_scope": "sat_scope", "master_pwd_key": "pass", "workspace_pat_scope": "sat_scope", "workspace_pat_token_prefix": "sat_token", "dashboard_id": "317f4809-8d9d-4956-a79a-6eee51412217", "dashboard_folder": "../../dashboards/", "dashboard_tag": "SAT", "use_mastercreds": true, "url": "https://satanalysis.cloud.databricks.com", "workspace_id": "2657683783405196", "cloud_type": "aws", "clusterid": "1115-184042-ntswg7ll"}'
+# ==============================================================================
+# Secret scope / key-name constants
+# ==============================================================================
+#
+# DEFAULT_SECRET_KEYS maps a *logical* name (stable API used throughout the
+# codebase) to the *physical* key string written/read from the Databricks secret
+# scope.  Operators who bring their own scope with different key names pass a
+# partial map via the `secret_key_names` job parameter (JSON string); it is
+# merged over this dict in `notebooks/Utils/initialize.py` so only overridden
+# entries need to be specified.
+#
+# Only TWO values must live in a secret scope:
+#   - client_secret  (an actual credential)
+#   - workspace_pat  (PAT prefix; dormant when use_mastercreds=True)
+#
+# All other values (account_id, client_id, etc.) are passed as direct
+# job base_parameters for new installs, with a scope fallback for backward
+# compatibility with 0.8.x installs that still have them stored as secrets.
+
+DEFAULT_SECRET_KEYS = {
+    "client_secret":              "client-secret",
+    "workspace_pat_token_prefix": "sat-token",
+    # Legacy / optional scope-based fallback keys for non-secret config.
+    # New installs carry these as job base_parameters; older installs will
+    # still resolve them from the scope via resolve_sat_value().
+    "account_id":                 "account-console-id",
+    "sql_warehouse_id":           "sql-warehouse-id",
+    "analysis_schema_name":       "analysis_schema_name",
+    "proxies":                    "proxies",
+    "use_sp_auth":                "use-sp-auth",
+    "client_id":                  "client-id",
+    "tenant_id":                  "tenant-id",
+    "subscription_id":            "subscription-id",
+}
+
+# Keys required per cloud for pre-flight validation in pre_run_config_check.
+REQUIRED_SECRET_KEYS_BY_CLOUD = {
+    "aws":   ["client_secret"],
+    "gcp":   ["client_secret"],
+    "azure": ["client_secret"],
+}
+
+def resolve_sat_value(logical, param_value, scope, keys, default=None, required=True):
+    """Resolve a SAT configuration value using the following priority order:
+
+    1. ``param_value`` – non-empty string from a job base_parameter / widget.
+    2. Databricks secret at ``scope`` / ``keys[logical]`` – legacy path, keeps
+       pre-0.9 installs (where all values lived in the scope) working.
+    3. ``default`` – if provided, used as a last-resort safe default.
+    4. Hard failure – raises ``ValueError`` naming the scope and physical key.
+
+    Parameters
+    ----------
+    logical:     logical key name, e.g. ``"account_id"``
+    param_value: string from the job parameter (may be empty / None)
+    scope:       Databricks secret scope name
+    keys:        resolved key map (DEFAULT_SECRET_KEYS merged with overrides)
+    default:     safe default to return when neither param nor secret exists
+    required:    when True and nothing resolves, raise instead of returning None
+    """
+    import warnings
+    # Step 1: direct parameter
+    if param_value and str(param_value).strip():
+        return str(param_value).strip()
+    # Step 2: scope fallback (best-effort)
+    physical = keys.get(logical, logical)
+    try:
+        val = dbutils.secrets.get(scope=scope, key=physical)  # noqa: F821
+        if val:
+            return val
+    except Exception:
+        pass
+    # Step 3: safe default
+    if default is not None:
+        warnings.warn(
+            f"SAT: '{logical}' not found in params or scope '{scope}' key "
+            f"'{physical}'; using default: {default!r}",
+            stacklevel=2,
+        )
+        return default
+    # Step 4: fail clearly
+    if required:
+        raise ValueError(
+            f"SAT configuration missing required value '{logical}'. "
+            f"Expected as job parameter or secret scope '{scope}' key '{physical}'.\n"
+            f"If running a Setup notebook interactively, set the 'secret_scope' widget "
+            f"to your configured scope name (the scope you specified during install) "
+            f"before running the notebook."
+        )
+    return None
+
+
+def read_sat_secret(scope, keys, logical, required=True, default=None):
+    """Read a value that *must* come from the secret scope (e.g. client_secret).
+
+    Unlike ``resolve_sat_value``, this function never accepts a direct
+    parameter – credentials should not travel through job base_parameters.
+
+    Raises ``ValueError`` naming the physical key and scope on failure.
+    """
+    physical = keys.get(logical, logical)
+    try:
+        val = dbutils.secrets.get(scope=scope, key=physical)  # noqa: F821
+        if val:
+            return val
+    except Exception as exc:
+        if required:
+            raise ValueError(
+                f"SAT: cannot read required secret '{logical}' from scope "
+                f"'{scope}' key '{physical}': {exc}"
+            ) from exc
+        return default
+    if required:
+        raise ValueError(
+            f"SAT: secret '{logical}' (scope='{scope}', key='{physical}') "
+            f"resolved to an empty value."
+        )
+    return default
 
 # COMMAND ----------
 
-JSONLOCALTESTB = '{"account_id": "", "sql_warehouse_id": "4a936419ee9b9d68",  "verbosity": "info", "master_name_scope": "sat_scope", "master_name_key": "user", "master_pwd_scope": "sat_scope", "master_pwd_key": "pass", "workspace_pat_scope": "sat_scope", "workspace_pat_token_prefix": "sat_token", "dashboard_id": "317f4809-8d9d-4956-a79a-6eee51412217", "dashboard_folder": "../../dashboards/", "dashboard_tag": "SAT", "use_mastercreds": true, "subscription_id": "", "tenant_id": "", "client_id": "", "client_secret": "", "generate_pat_tokens": false, "url": "https://adb-83xxx7.17.azuredatabricks.net", "workspace_id": "83xxxx7", "clusterid": "0105-242242-ir40aiai", "cloud_type":"azure"}'
+# For testing
+JSONLOCALTESTA = '{"account_id": "", "sql_warehouse_id": "", "verbosity": "info", "master_name_scope": "sat_scope", "master_name_key": "client-secret", "master_pwd_scope": "sat_scope", "master_pwd_key": "client-secret", "workspace_pat_scope": "sat_scope", "workspace_pat_token_prefix": "sat-token", "dashboard_id": "317f4809-8d9d-4956-a79a-6eee51412217", "dashboard_folder": "../../dashboards/", "dashboard_tag": "SAT", "use_mastercreds": true, "url": "https://satanalysis.cloud.databricks.com", "workspace_id": "2657683783405196", "cloud_type": "aws", "clusterid": "1115-184042-ntswg7ll", "secret_scope": "sat_scope", "secret_keys": {"client_secret": "client-secret", "workspace_pat_token_prefix": "sat-token"}}'
+
+# COMMAND ----------
+
+JSONLOCALTESTB = '{"account_id": "", "sql_warehouse_id": "4a936419ee9b9d68",  "verbosity": "info", "master_name_scope": "sat_scope", "master_name_key": "client-secret", "master_pwd_scope": "sat_scope", "master_pwd_key": "client-secret", "workspace_pat_scope": "sat_scope", "workspace_pat_token_prefix": "sat-token", "dashboard_id": "317f4809-8d9d-4956-a79a-6eee51412217", "dashboard_folder": "../../dashboards/", "dashboard_tag": "SAT", "use_mastercreds": true, "subscription_id": "", "tenant_id": "", "client_id": "", "client_secret": "", "generate_pat_tokens": false, "url": "https://adb-83xxx7.17.azuredatabricks.net", "workspace_id": "83xxxx7", "clusterid": "0105-242242-ir40aiai", "cloud_type":"azure", "secret_scope": "sat_scope", "secret_keys": {"client_secret": "client-secret", "workspace_pat_token_prefix": "sat-token"}}'

--- a/notebooks/Utils/initialize.py
+++ b/notebooks/Utils/initialize.py
@@ -28,33 +28,94 @@ cloud_type = getCloudType(hostname)
 # MAGIC * **verbosity** (optional). debug, info, warning, error, critical
 # MAGIC * **maxpages** for paginated calls, how many max pages to iterate before stopping
 # MAGIC * **timebetweencalls** time in secs between api calls. This is to prevent rejections with too many api calls
-# MAGIC * **master_name_scope** Secret Scope for Account Name
-# MAGIC * **master_name_key** Secret Key for Account Name
-# MAGIC * **master_pwd_scope** Secret Scope for Account Password
-# MAGIC * **master_pwd_key** Secret Key for Account Password
+# MAGIC * **master_name_scope** Secret Scope that holds the SAT client secret
 # MAGIC * **workspace_pat_scope** Secret Scope for Workspace PAT
 # MAGIC * **workspace_pat_token_prefix** Secret Key prefix for Workspace PAT. Workspace ID will automatically be appended to this per workspace
 # MAGIC * **use_mastercreds** (optional) Use master account credentials for all workspaces
 # MAGIC * **sat_version** Version of the SAT version being used
-
-# COMMAND ----------
-
-SECRETS_SCOPE = "sat_scope"
+# MAGIC
+# MAGIC ##### BYO secret scope / key names
+# MAGIC * **secret_scope** Name of the Databricks secret scope SAT reads from (default: ``sat_scope``)
+# MAGIC * **secret_key_names** JSON map of logical -> physical key name overrides, e.g.
+# MAGIC   ``{"client_secret": "my-sp-secret"}`` (empty = use defaults)
+# MAGIC
+# MAGIC ##### Direct configuration parameters (new in 0.9)
+# MAGIC The values below can be supplied as job ``base_parameters`` (or notebook
+# MAGIC widgets) instead of—or in addition to—storing them in the secret scope.
+# MAGIC When a parameter is non-empty it takes priority; an empty value falls back
+# MAGIC to the scope so that 0.8.x installs continue to work unchanged.
+# MAGIC * **account_id_param** – Databricks Account UUID
+# MAGIC * **client_id_param** – Service Principal Application (client) ID
+# MAGIC * **tenant_id_param** – Azure Tenant ID (Azure only)
+# MAGIC * **subscription_id_param** – Azure Subscription ID (Azure only)
+# MAGIC * **sql_warehouse_id_param** – SQL Warehouse ID
+# MAGIC * **analysis_schema_name_param** – Unity Catalog schema for SAT tables
+# MAGIC * **proxies_param** – JSON proxy map, e.g. ``{"http": "http://proxy:8080"}``
+# MAGIC * **use_sp_auth_param** – ``"true"`` or ``"false"`` (AWS/GCP only)
 
 # COMMAND ----------
 
 import json
 
+# ---------------------------------------------------------------------------
+# Widget declarations
+# All widgets default to empty string; non-empty value wins over scope lookup.
+#
+# When running a Setup notebook interactively (not via a job):
+#   - The secret_scope widget defaults to "sat_scope" for the common case.
+#     If you used a different scope during install, change this widget first.
+#   - Leave value widgets blank to read from the scope, or fill them in directly.
+# When running via a SAT job, base_parameters populate these automatically.
+# ---------------------------------------------------------------------------
+dbutils.widgets.text("secret_scope",            "sat_scope", "Secret Scope Name")
+dbutils.widgets.text("secret_key_names",         "{}",        "Secret Key Name Overrides (JSON)")
+dbutils.widgets.text("account_id_param",         "",          "Account ID")
+dbutils.widgets.text("client_id_param",          "",          "Client ID")
+dbutils.widgets.text("tenant_id_param",          "",          "Tenant ID (Azure)")
+dbutils.widgets.text("subscription_id_param",    "",          "Subscription ID (Azure)")
+dbutils.widgets.text("sql_warehouse_id_param",   "",          "SQL Warehouse ID")
+dbutils.widgets.text("analysis_schema_name_param","",         "Analysis Schema Name")
+dbutils.widgets.text("proxies_param",            "",          "Proxies JSON")
+dbutils.widgets.text("use_sp_auth_param",        "",          "Use SP Auth (true/false)")
+
+# ---------------------------------------------------------------------------
+# Resolve scope and key map
+# ---------------------------------------------------------------------------
+SECRETS_SCOPE = dbutils.widgets.get("secret_scope").strip() or "sat_scope"
+
+_key_overrides = {}
+try:
+    _raw = dbutils.widgets.get("secret_key_names").strip()
+    if _raw and _raw != "{}":
+        _key_overrides = json.loads(_raw)
+except Exception:
+    pass
+
+SECRET_KEYS = {**DEFAULT_SECRET_KEYS, **_key_overrides}
+
+# COMMAND ----------
+
+# ---------------------------------------------------------------------------
+# Resolve non-secret config values (param → scope fallback → safe default)
+# ---------------------------------------------------------------------------
+_account_id           = resolve_sat_value("account_id",           dbutils.widgets.get("account_id_param"),          SECRETS_SCOPE, SECRET_KEYS)
+_sql_warehouse_id     = resolve_sat_value("sql_warehouse_id",     dbutils.widgets.get("sql_warehouse_id_param"),    SECRETS_SCOPE, SECRET_KEYS)
+_analysis_schema_name = resolve_sat_value("analysis_schema_name", dbutils.widgets.get("analysis_schema_name_param"),SECRETS_SCOPE, SECRET_KEYS)
+
+_proxies_raw = resolve_sat_value("proxies", dbutils.widgets.get("proxies_param"), SECRETS_SCOPE, SECRET_KEYS, default="{}")
+try:
+    _proxies = json.loads(_proxies_raw)
+except (json.JSONDecodeError, TypeError):
+    _proxies = {}
+
 json_ = {
-    "account_id": dbutils.secrets.get(scope=SECRETS_SCOPE, key="account-console-id"),
-    "sql_warehouse_id": dbutils.secrets.get(scope=SECRETS_SCOPE, key="sql-warehouse-id"),
-    "analysis_schema_name": dbutils.secrets.get(
-        scope=SECRETS_SCOPE, key="analysis_schema_name"
-    ),
+    "account_id":           _account_id,
+    "sql_warehouse_id":     _sql_warehouse_id,
+    "analysis_schema_name": _analysis_schema_name,
     "verbosity": "info",
     "maxpages":10,
     "timebetweencalls":1,
-    "proxies": json.loads(dbutils.secrets.get(scope=SECRETS_SCOPE, key="proxies")),
+    "proxies": _proxies,
 }
 
 # COMMAND ----------
@@ -82,11 +143,10 @@ json_.update(
 json_.update(
     {
         "master_name_scope": SECRETS_SCOPE,
-        "master_name_key": "user",
-        "master_pwd_scope": SECRETS_SCOPE,
-        "master_pwd_key": "pass",
+        "master_pwd_scope":  SECRETS_SCOPE,
         "workspace_pat_scope": SECRETS_SCOPE,
-        "workspace_pat_token_prefix": "sat-token",
+        "workspace_pat_token_prefix": SECRET_KEYS.get("workspace_pat_token_prefix", "sat-token"),
+        "client_secret_key": SECRET_KEYS.get("client_secret", "client-secret"),
         "dashboard_id": "317f4809-8d9d-4956-a79a-6eee51412217",
         "dashboard_folder": f"{basePath()}/dashboards/",
         "dashboard_tag": "SAT",
@@ -98,6 +158,10 @@ json_.update(
         #   - DoD (IL4/IL5): See https://docs.databricks.com/aws/en/security/privacy/gov-cloud
         "accounts_console": "",
         "sat_version": "0.7.0",
+        # Expose scope + key map so child notebooks and diagnostic notebooks
+        # can resolve additional keys without re-reading widgets.
+        "secret_scope": SECRETS_SCOPE,
+        "secret_keys":  SECRET_KEYS,
     }
 )
 
@@ -109,19 +173,24 @@ if cloud_type == "gcp":
     sp_auth = {
         "use_sp_auth": "False",
         "client_id": "",
-        "client_secret_key": "client-secret",
+        "client_secret_key": SECRET_KEYS.get("client_secret", "client-secret"),
     }
-    try:
-        use_sp_auth = (
-            dbutils.secrets.get(scope=SECRETS_SCOPE, key="use-sp-auth").lower() == "true"
+    _use_sp_raw = resolve_sat_value(
+        "use_sp_auth", dbutils.widgets.get("use_sp_auth_param"), SECRETS_SCOPE, SECRET_KEYS,
+        default="False", required=False,
+    )
+    use_sp_auth = str(_use_sp_raw).lower() == "true"
+    if use_sp_auth:
+        sp_auth["use_sp_auth"] = "True"
+        _client_id = resolve_sat_value(
+            "client_id", dbutils.widgets.get("client_id_param"), SECRETS_SCOPE, SECRET_KEYS
         )
-        if use_sp_auth:
-            sp_auth["use_sp_auth"] = "True"
-            sp_auth["client_id"] = dbutils.secrets.get(
-                scope=SECRETS_SCOPE, key="client-id"
-            )
-    except:
-        pass
+        if _client_id:
+            sp_auth["client_id"] = _client_id
+        else:
+            import warnings
+            warnings.warn("SAT: use_sp_auth=True but client_id is empty; SP auth disabled.", stacklevel=1)
+            sp_auth["use_sp_auth"] = "False"
     json_.update(sp_auth)
 
 # COMMAND ----------
@@ -130,16 +199,16 @@ if cloud_type == "gcp":
 if cloud_type == "azure":
     json_.update(
         {
-            "subscription_id": dbutils.secrets.get(
-                scope=SECRETS_SCOPE, key="subscription-id"
-            ),  # Azure subscriptionId
-            "tenant_id": dbutils.secrets.get(
-                scope=SECRETS_SCOPE, key="tenant-id"
-            ),  # The Directory (tenant) ID for the application registered in Azure AD.
-            "client_id": dbutils.secrets.get(
-                scope=SECRETS_SCOPE, key="client-id"
-            ),  # The Application (client) ID for the application registered in Azure AD.
-            "client_secret_key": "client-secret",  # The secret generated by AAD during your confidential app registration
+            "subscription_id": resolve_sat_value(
+                "subscription_id", dbutils.widgets.get("subscription_id_param"), SECRETS_SCOPE, SECRET_KEYS
+            ),
+            "tenant_id": resolve_sat_value(
+                "tenant_id", dbutils.widgets.get("tenant_id_param"), SECRETS_SCOPE, SECRET_KEYS
+            ),
+            "client_id": resolve_sat_value(
+                "client_id", dbutils.widgets.get("client_id_param"), SECRETS_SCOPE, SECRET_KEYS
+            ),
+            "client_secret_key": SECRET_KEYS.get("client_secret", "client-secret"),
             "use_mastercreds": True,
         }
     )
@@ -152,22 +221,54 @@ if cloud_type == "aws":
     sp_auth = {
         "use_sp_auth": "False",
         "client_id": "",
-        "client_secret_key": "client-secret",
+        "client_secret_key": SECRET_KEYS.get("client_secret", "client-secret"),
     }
-    try:
-        use_sp_auth = (
-            dbutils.secrets.get(scope=SECRETS_SCOPE, key="use-sp-auth").lower() == "true"
+    _use_sp_raw = resolve_sat_value(
+        "use_sp_auth", dbutils.widgets.get("use_sp_auth_param"), SECRETS_SCOPE, SECRET_KEYS,
+        default="False", required=False,
+    )
+    use_sp_auth = str(_use_sp_raw).lower() == "true"
+    if use_sp_auth:
+        sp_auth["use_sp_auth"] = "True"
+        _client_id = resolve_sat_value(
+            "client_id", dbutils.widgets.get("client_id_param"), SECRETS_SCOPE, SECRET_KEYS
         )
-        if use_sp_auth:
-            sp_auth["use_sp_auth"] = "True"
-            sp_auth["client_id"] = dbutils.secrets.get(
-                scope=SECRETS_SCOPE, key="client-id"
-            )
-    except:
-        pass
+        if _client_id:
+            sp_auth["client_id"] = _client_id
+        else:
+            import warnings
+            warnings.warn("SAT: use_sp_auth=True but client_id is empty; SP auth disabled.", stacklevel=1)
+            sp_auth["use_sp_auth"] = "False"
     json_.update(sp_auth)
 
 # COMMAND ----------
+
+# COMMAND ----------
+
+# ---------------------------------------------------------------------------
+# Parameters to forward to child notebooks spawned via dbutils.notebook.run()
+#
+# dbutils.notebook.run() creates an ISOLATED widget context — the child does
+# NOT inherit the parent's widgets.  Any spawner (e.g. security_analysis_initializer)
+# must pass SAT_CHILD_PARAMS as the arguments dict, otherwise the child's
+# initialize.py falls back to scope reads that fail for installs where values
+# travel as job base_parameters.
+#
+# Placed here (after the cloud-specific blocks) so all json_ keys — including
+# client_id / tenant_id / subscription_id / use_sp_auth — are fully populated.
+# ---------------------------------------------------------------------------
+SAT_CHILD_PARAMS = {
+    "secret_scope":                SECRETS_SCOPE,
+    "secret_key_names":            json.dumps(_key_overrides) if _key_overrides else "{}",
+    "account_id_param":            json_.get("account_id", "") or "",
+    "client_id_param":             json_.get("client_id", "") or "",
+    "tenant_id_param":             json_.get("tenant_id", "") or "",
+    "subscription_id_param":       json_.get("subscription_id", "") or "",
+    "sql_warehouse_id_param":      json_.get("sql_warehouse_id", "") or "",
+    "analysis_schema_name_param":  json_.get("analysis_schema_name", "") or "",
+    "proxies_param":               json.dumps(json_.get("proxies", {})),
+    "use_sp_auth_param":           str(json_.get("use_sp_auth", "")),
+}
 
 # COMMAND ----------
 
@@ -200,4 +301,3 @@ readBestPracticesConfigsFile()
 
 # Initialize sat dasf mapping
 load_sat_dasf_mapping()
-

--- a/notebooks/brickhound/00_config.py
+++ b/notebooks/brickhound/00_config.py
@@ -53,12 +53,16 @@
 # MAGIC
 # MAGIC **If SAT is already installed:**
 # MAGIC - No additional configuration needed
-# MAGIC - BrickHound automatically uses credentials from `sat_scope` secret scope
-# MAGIC - Required secrets (already configured by SAT):
-# MAGIC   - `account-console-id` (Account UUID)
-# MAGIC   - `client-id` (Service Principal Application ID)
-# MAGIC   - `client-secret` (Service Principal OAuth Secret)
-# MAGIC   - `analysis_schema_name` (Unity Catalog schema: `catalog.schema`)
+# MAGIC - BrickHound automatically uses credentials from the configured SAT secret scope
+# MAGIC   (default: `sat_scope`; override via the `secret_scope` job parameter)
+# MAGIC - The service principal `client-secret` must remain in the secret scope.
+# MAGIC   All other values (`account-console-id`, `client-id`, etc.) can be supplied
+# MAGIC   as direct job parameters instead (see `notebooks/Utils/initialize.py`).
+# MAGIC - Required secrets/params (already configured by SAT installer):
+# MAGIC   - `account-console-id` / `account_id_param` (Account UUID)
+# MAGIC   - `client-id` / `client_id_param` (Service Principal Application ID)
+# MAGIC   - `client-secret` (Service Principal OAuth Secret — scope only)
+# MAGIC   - `analysis_schema_name` / `analysis_schema_name_param` (Unity Catalog schema: `catalog.schema`)
 # MAGIC
 # MAGIC **If SAT is not installed:**
 # MAGIC - Run the SAT installer: `./install.sh` in the SAT project root
@@ -78,8 +82,11 @@
 # Configuration is automatically read from SAT's sat_scope
 
 
-# Read catalog and schema from SAT configuration
-analysis_schema = dbutils.secrets.get(scope=SECRETS_SCOPE, key="analysis_schema_name")
+# Read catalog and schema from SAT configuration.
+# json_["analysis_schema_name"] is resolved by initialize.py via the
+# resolve_sat_value() chain (param → scope → fail), so no direct secret
+# read is needed here.
+analysis_schema = json_["analysis_schema_name"]
 CATALOG = analysis_schema.split('.')[0]
 SCHEMA = analysis_schema.split('.')[1]
 
@@ -93,7 +100,7 @@ print("BrickHound Configuration (SAT Integration)")
 print("=" * 60)
 print(f"Catalog:        {CATALOG}")
 print(f"Schema:         {SCHEMA}")
-print(f"Secrets Scope:  {SECRETS_SCOPE}")
+print(f"Secrets Scope:  {json_.get('secret_scope', SECRETS_SCOPE)}")
 print(f"Vertices:       {VERTICES_TABLE}")
 print(f"Edges:          {EDGES_TABLE}")
 print(f"Metadata:       {COLLECTION_METADATA_TABLE}")

--- a/notebooks/brickhound/05_share_to_account.py
+++ b/notebooks/brickhound/05_share_to_account.py
@@ -121,13 +121,28 @@ ACCOUNTS_HOST = resolve_accounts_host(
     cloud_type, WORKSPACE_URL, json_.get("accounts_console", "")
 )
 ACCOUNT_ID    = json_["account_id"]
-CLIENT_ID     = dbutils.secrets.get(scope=SECRETS_SCOPE, key="client-id")
-CLIENT_SECRET = dbutils.secrets.get(scope=SECRETS_SCOPE, key="client-secret")
+# client_id is a non-secret config value; json_["client_id"] is populated by
+# initialize.py via the param->scope resolution chain.
+CLIENT_ID     = json_.get("client_id") or read_sat_secret(
+    json_.get("secret_scope", SECRETS_SCOPE),
+    json_.get("secret_keys", SECRET_KEYS),
+    "client_id",
+)
+# client_secret is an actual credential; always read from the scope.
+CLIENT_SECRET = read_sat_secret(
+    json_.get("secret_scope", SECRETS_SCOPE),
+    json_.get("secret_keys", SECRET_KEYS),
+    "client_secret",
+)
 
 # tenant-id is required for Azure (Entra/MSAL auth); absent on AWS/GCP.
 TENANT_ID = None
 if cloud_type == "azure":
-    TENANT_ID = json_.get("tenant_id") or dbutils.secrets.get(scope=SECRETS_SCOPE, key="tenant-id")
+    TENANT_ID = json_.get("tenant_id") or read_sat_secret(
+        json_.get("secret_scope", SECRETS_SCOPE),
+        json_.get("secret_keys", SECRET_KEYS),
+        "tenant_id",
+    )
 
 SHARED_TO_ACCOUNT_TABLE = f"{CATALOG}.{SCHEMA}.brickhound_shared_to_account"
 

--- a/notebooks/brickhound/06_privileged_non_idp_identities.py
+++ b/notebooks/brickhound/06_privileged_non_idp_identities.py
@@ -109,13 +109,25 @@ WORKSPACE_URL = (
 )
 ACCOUNTS_HOST = resolve_accounts_host(cloud_type, WORKSPACE_URL, json_.get("accounts_console", ""))
 ACCOUNT_ID    = json_["account_id"]
-CLIENT_ID     = dbutils.secrets.get(scope=SECRETS_SCOPE, key="client-id")
-CLIENT_SECRET = dbutils.secrets.get(scope=SECRETS_SCOPE, key="client-secret")
+CLIENT_ID     = json_.get("client_id") or read_sat_secret(
+    json_.get("secret_scope", SECRETS_SCOPE),
+    json_.get("secret_keys", SECRET_KEYS),
+    "client_id",
+)
+CLIENT_SECRET = read_sat_secret(
+    json_.get("secret_scope", SECRETS_SCOPE),
+    json_.get("secret_keys", SECRET_KEYS),
+    "client_secret",
+)
 
 # tenant-id is required for Azure (Entra/MSAL auth); absent on AWS/GCP.
 TENANT_ID = None
 if cloud_type == "azure":
-    TENANT_ID = json_.get("tenant_id") or dbutils.secrets.get(scope=SECRETS_SCOPE, key="tenant-id")
+    TENANT_ID = json_.get("tenant_id") or read_sat_secret(
+        json_.get("secret_scope", SECRETS_SCOPE),
+        json_.get("secret_keys", SECRET_KEYS),
+        "tenant_id",
+    )
 
 PRIVILEGED_NON_IDP_TABLE = f"{CATALOG}.{SCHEMA}.brickhound_privileged_non_idp"
 

--- a/notebooks/brickhound/07_denylist_candidates.py
+++ b/notebooks/brickhound/07_denylist_candidates.py
@@ -82,13 +82,25 @@ WORKSPACE_URL = (
 )
 ACCOUNTS_HOST = resolve_accounts_host(cloud_type, WORKSPACE_URL, json_.get("accounts_console", ""))
 ACCOUNT_ID    = json_["account_id"]
-CLIENT_ID     = dbutils.secrets.get(scope=SECRETS_SCOPE, key="client-id")
-CLIENT_SECRET = dbutils.secrets.get(scope=SECRETS_SCOPE, key="client-secret")
+CLIENT_ID     = json_.get("client_id") or read_sat_secret(
+    json_.get("secret_scope", SECRETS_SCOPE),
+    json_.get("secret_keys", SECRET_KEYS),
+    "client_id",
+)
+CLIENT_SECRET = read_sat_secret(
+    json_.get("secret_scope", SECRETS_SCOPE),
+    json_.get("secret_keys", SECRET_KEYS),
+    "client_secret",
+)
 
 # tenant-id is required for Azure (Entra/MSAL auth); absent on AWS/GCP.
 TENANT_ID = None
 if cloud_type == "azure":
-    TENANT_ID = json_.get("tenant_id") or dbutils.secrets.get(scope=SECRETS_SCOPE, key="tenant-id")
+    TENANT_ID = json_.get("tenant_id") or read_sat_secret(
+        json_.get("secret_scope", SECRETS_SCOPE),
+        json_.get("secret_keys", SECRET_KEYS),
+        "tenant_id",
+    )
 
 DENYLIST_CANDIDATES_TABLE = f"{CATALOG}.{SCHEMA}.brickhound_denylist_candidates"
 print(f"Accounts host: {ACCOUNTS_HOST}")

--- a/notebooks/brickhound/README.md
+++ b/notebooks/brickhound/README.md
@@ -58,8 +58,8 @@ https://<workspace-url>/apps/brickhound-sat
 ## Configuration
 
 BrickHound automatically uses SAT's configuration:
-- **Credentials**: From `sat_scope` secret scope
-- **Schema**: From SAT's `analysis_schema_name`
+- **Credentials**: From the configured SAT secret scope (default `sat_scope`; only `client_secret` must live there — all other values are passed as job parameters with scope fallback)
+- **Schema**: From SAT's `analysis_schema_name` (resolved by `initialize.py` via job parameter → scope → fail)
 - **Tables**: `brickhound_vertices`, `brickhound_edges`, `brickhound_collection_metadata`, `brickhound_shared_to_account`
 
 No additional configuration needed if SAT is installed!
@@ -84,7 +84,7 @@ Both write to the same Unity Catalog schema for unified security analysis.
 - Check job logs for errors
 
 **Authentication failed?**
-- Verify SAT is installed (`sat_scope` exists)
+- Verify the configured SAT secret scope exists and contains the `client-secret` key (or the key name you configured)
 - Check service principal has Account Admin role
 
 **Tables not found?**
@@ -93,6 +93,5 @@ Both write to the same Unity Catalog schema for unified security analysis.
 
 ## Documentation
 
-- **Integration Guide**: `/docs/BRICKHOUND_INTEGRATION.md`
-- **Permissions Reference**: `/docs/brickhound_PERMISSIONS.md`
-- **Main README**: `/docs/brickhound_README.md`
+- **Secret Scope Reference**: [docs/sat/docs/installation/secret-scope.mdx](../docs/sat/docs/installation/secret-scope.mdx)
+- **Upgrade Notes**: [docs/sat/docs/upgrade.mdx](../docs/sat/docs/upgrade.mdx)

--- a/notebooks/diagnosis/pre_run_config_check.py
+++ b/notebooks/diagnosis/pre_run_config_check.py
@@ -19,6 +19,10 @@
 
 secret_scopes = dbutils.secrets.listScopes()
 
+# Resolve the configured scope and key map from json_ (set by initialize.py).
+# Falls back to defaults for standalone / manual notebook runs.
+_sat_scope = json_.get("secret_scope", json_.get("master_name_scope", "sat_scope"))
+_sat_keys  = json_.get("secret_keys", DEFAULT_SECRET_KEYS)
 
 # COMMAND ----------
 
@@ -28,16 +32,16 @@ secret_scopes = dbutils.secrets.listScopes()
 # COMMAND ----------
 
 found = False
-for secret_scope in secret_scopes:
-   
-   if secret_scope.name == json_['master_name_scope']:
-      print('Your SAT configuration has the required scope name')
-      found=True
+for _scope_entry in secret_scopes:
+   if _scope_entry.name == _sat_scope:
+      print(f'Your SAT configuration has the required scope: {_sat_scope}')
+      found = True
       break
 if not found:
-   dbutils.notebook.exit(f'Your SAT configuration is missing required scope {json_["master_name_scope"]}, please review setup instructions')
-
-      
+   dbutils.notebook.exit(
+       f'Your SAT configuration is missing required scope "{_sat_scope}". '
+       f'Please review setup instructions or set the secret_scope job parameter.'
+   )
 
 # COMMAND ----------
 
@@ -55,50 +59,31 @@ cloud_type = getCloudType(hostname)
 
 # MAGIC %md
 # MAGIC ### Let us check if there are required configs in the SAT scope
+# MAGIC
+# MAGIC For 0.9+ installs most values are delivered as job parameters (not secrets),
+# MAGIC so this check validates that **at minimum** the credential secret is readable.
+# MAGIC Non-secret values (account_id, client_id, etc.) are verified via json_ which
+# MAGIC was already populated by initialize.py — a missing param or scope value would
+# MAGIC have caused initialize.py to fail before reaching this point.
 
 # COMMAND ----------
 
+# Only client_secret is required to be in the scope for all clouds.
+_missing = []
+_client_secret_key = _sat_keys.get("client_secret", "client-secret")
+try:
+   dbutils.secrets.get(scope=_sat_scope, key=_client_secret_key)
+except Exception as e:
+   _missing.append(f"  - client_secret (scope='{_sat_scope}', key='{_client_secret_key}'): {e}")
 
-if cloud_type == "aws":
-   try:
-      dbutils.secrets.get(scope=json_['master_name_scope'], key='account-console-id')
-      dbutils.secrets.get(scope=json_['master_name_scope'], key='sql-warehouse-id')
-      dbutils.secrets.get(scope=json_['master_name_scope'], key='client-id')
-      dbutils.secrets.get(scope=json_['master_name_scope'], key='client-secret')
-      dbutils.secrets.get(scope=json_['master_name_scope'], key='use-sp-auth')
-      dbutils.secrets.get(scope=json_['master_name_scope'], key="analysis_schema_name")
-      print("Your SAT configuration is has required secret names")
-   except Exception as e:
-      dbutils.notebook.exit(f'Your SAT configuration is missing required secret, please review setup instructions {e}')  
-
-# COMMAND ----------
-
-if cloud_type == "azure":
-   try:
-      dbutils.secrets.get(scope=json_['master_name_scope'], key='account-console-id')
-      dbutils.secrets.get(scope=json_['master_name_scope'], key='sql-warehouse-id')
-      dbutils.secrets.get(scope=json_['master_name_scope'], key='subscription-id')
-      dbutils.secrets.get(scope=json_['master_name_scope'], key='tenant-id')
-      dbutils.secrets.get(scope=json_['master_name_scope'], key='client-id')
-      dbutils.secrets.get(scope=json_['master_name_scope'], key='client-secret')
-      dbutils.secrets.get(scope=json_['master_name_scope'], key="analysis_schema_name")
-      print("Your SAT configuration has required secret names")
-   except Exception as e:
-      dbutils.notebook.exit(f'Your SAT configuration is missing required secret, please review setup instructions {e}')  
-
-# COMMAND ----------
-
-if cloud_type == "gcp":
-   try:
-      dbutils.secrets.get(scope=json_['master_name_scope'], key='account-console-id')
-      dbutils.secrets.get(scope=json_['master_name_scope'], key='sql-warehouse-id')
-      dbutils.secrets.get(scope=json_['master_name_scope'], key='client-id')
-      dbutils.secrets.get(scope=json_['master_name_scope'], key='client-secret')
-      dbutils.secrets.get(scope=json_['master_name_scope'], key='use-sp-auth')
-      dbutils.secrets.get(scope=json_['master_name_scope'], key="analysis_schema_name")
-      print("Your SAT configuration is has required secret names")
-   except Exception as e:
-      dbutils.notebook.exit(f'Your SAT configuration is missing required secret, please review setup instructions {e}')
+if _missing:
+   dbutils.notebook.exit(
+       "Your SAT configuration is missing required secret(s):\n"
+       + "\n".join(_missing)
+       + "\nPlease review setup instructions."
+   )
+else:
+   print(f"SAT scope '{_sat_scope}' has the required credential secret.")
 
 # COMMAND ----------
 

--- a/notebooks/diagnosis/sat_diagnosis_aws.py
+++ b/notebooks/diagnosis/sat_diagnosis_aws.py
@@ -91,15 +91,19 @@ if not found:
 # COMMAND ----------
 
 try:
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='account-console-id')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='sql-warehouse-id')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='client-id')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='client-secret')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='use-sp-auth')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key="analysis_schema_name")
-   print("Your SAT configuration is has required secret names")
+   # Validate that all required values are accessible (param or scope).
+   # account_id, client_id already in json_ from initialize.py resolution.
+   assert json_.get('account_id'), "account_id missing"
+   assert json_.get('use_sp_auth') or json_.get('client_id'), "client_id/use_sp_auth missing"
+   # client_secret must be in the scope.
+   _sat_scope = json_.get("secret_scope", json_['master_name_scope'])
+   _sat_keys  = json_.get("secret_keys", DEFAULT_SECRET_KEYS)
+   dbutils.secrets.get(scope=_sat_scope, key=_sat_keys.get("client_secret", "client-secret"))
+   assert json_.get('sql_warehouse_id'), "sql_warehouse_id missing"
+   assert json_.get('analysis_schema_name'), "analysis_schema_name missing"
+   print("Your SAT configuration has all required values")
 except Exception as e:
-   dbutils.notebook.exit(f'Your SAT configuration is missing required secret, please review setup instructions {e}')  
+   dbutils.notebook.exit(f'Your SAT configuration is missing a required value, please review setup instructions: {e}')
 
 # COMMAND ----------
 
@@ -108,12 +112,30 @@ except Exception as e:
 
 # COMMAND ----------
 
-sat_scope = json_['master_name_scope']
+sat_scope = json_.get("secret_scope", json_['master_name_scope'])
+_sat_keys = json_.get("secret_keys", DEFAULT_SECRET_KEYS)
 
+# List scope keys and report presence/length — never print the values.
+print(f"Secret scope: {sat_scope}")
+print("Keys present in scope:")
 for key in dbutils.secrets.list(sat_scope):
-    print(key.key)
-    secretvalue = dbutils.secrets.get(scope=sat_scope, key=key.key)
-    print(secretvalue)
+    try:
+        val = dbutils.secrets.get(scope=sat_scope, key=key.key)
+        print(f"  {key.key}: {'[set, {0} chars]'.format(len(val)) if val else '[empty]'}")
+    except Exception as e:
+        print(f"  {key.key}: [error reading: {e}]")
+
+# Show non-secret config values from json_ directly (safe to print).
+print(f"\nConfig values (from job parameters / scope fallback):")
+for field in ("account_id", "client_id", "tenant_id", "subscription_id",
+              "sql_warehouse_id", "analysis_schema_name", "use_sp_auth"):
+    v = json_.get(field, "<not set>")
+    # Partially mask UUIDs and IDs for log safety.
+    if v and len(str(v)) > 8:
+        display_v = f"{str(v)[:4]}...{str(v)[-4:]}"
+    else:
+        display_v = v
+    print(f"  {field}: {display_v}")
 
 # COMMAND ----------
 
@@ -156,7 +178,9 @@ def getAWSTokenwithOAuth(source, baccount, client_id, client_secret):
 
 # COMMAND ----------
 
-token = getAWSTokenwithOAuth(workspaceUrl,False, dbutils.secrets.get(scope=json_['master_name_scope'], key='client-id'), dbutils.secrets.get(scope=json_['master_name_scope'], key='client-secret'))
+token = getAWSTokenwithOAuth(workspaceUrl, False,
+    json_.get("client_id") or dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("client_id", "client-id")),
+    dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("client_secret", "client-secret")))
 
 print("Workspace token obtained" if token else "Workspace token FAILED")
 
@@ -196,7 +220,11 @@ print(response.json())
 
 # COMMAND ----------
 
-access_token = getAWSTokenwithOAuth(dbutils.secrets.get(scope=json_['master_name_scope'], key='account-console-id'),True, dbutils.secrets.get(scope=json_['master_name_scope'], key='client-id'), dbutils.secrets.get(scope=json_['master_name_scope'], key='client-secret'))
+access_token = getAWSTokenwithOAuth(
+    json_.get("account_id") or dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("account_id", "account-console-id")),
+    True,
+    json_.get("client_id") or dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("client_id", "client-id")),
+    dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("client_secret", "client-secret")))
 
 print("Account token obtained" if access_token else "Account token FAILED")
 
@@ -212,7 +240,7 @@ print("Account token obtained" if access_token else "Account token FAILED")
 
 import requests
 
-DATABRICKS_ACCOUNT_ID = dbutils.secrets.get(scope=sat_scope, key="account-console-id")
+DATABRICKS_ACCOUNT_ID = json_.get("account_id") or dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("account_id", "account-console-id"))
 url = f'https://accounts.cloud.databricks.com/api/2.0/accounts/{DATABRICKS_ACCOUNT_ID}/workspaces'
 
 ## Note: The access token must be generated for a Service Principal that has account admin privileges to run this command.  

--- a/notebooks/diagnosis/sat_diagnosis_aws_govcloud.py
+++ b/notebooks/diagnosis/sat_diagnosis_aws_govcloud.py
@@ -91,15 +91,16 @@ if not found:
 # COMMAND ----------
 
 try:
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='account-console-id')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='sql-warehouse-id')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='client-id')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='client-secret')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='use-sp-auth')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key="analysis_schema_name")
-   print("Your SAT configuration has required secret names")
+   assert json_.get('account_id'), "account_id missing"
+   assert json_.get('use_sp_auth') or json_.get('client_id'), "client_id/use_sp_auth missing"
+   _sat_scope = json_.get("secret_scope", json_['master_name_scope'])
+   _sat_keys  = json_.get("secret_keys", DEFAULT_SECRET_KEYS)
+   dbutils.secrets.get(scope=_sat_scope, key=_sat_keys.get("client_secret", "client-secret"))
+   assert json_.get('sql_warehouse_id'), "sql_warehouse_id missing"
+   assert json_.get('analysis_schema_name'), "analysis_schema_name missing"
+   print("Your SAT configuration has all required values")
 except Exception as e:
-   dbutils.notebook.exit(f'Your SAT configuration is missing required secret, please review setup instructions {e}')  
+   dbutils.notebook.exit(f'Your SAT configuration is missing a required value, please review setup instructions: {e}')
 
 # COMMAND ----------
 
@@ -108,12 +109,23 @@ except Exception as e:
 
 # COMMAND ----------
 
-sat_scope = json_['master_name_scope']
+sat_scope = json_.get("secret_scope", json_['master_name_scope'])
+_sat_keys = json_.get("secret_keys", DEFAULT_SECRET_KEYS)
 
+print(f"Secret scope: {sat_scope}")
+print("Keys present in scope:")
 for key in dbutils.secrets.list(sat_scope):
-    print(key.key)
-    secretvalue = dbutils.secrets.get(scope=sat_scope, key=key.key)
-    print(secretvalue)
+    try:
+        val = dbutils.secrets.get(scope=sat_scope, key=key.key)
+        print(f"  {key.key}: {'[set, {0} chars]'.format(len(val)) if val else '[empty]'}")
+    except Exception as e:
+        print(f"  {key.key}: [error reading: {e}]")
+
+print(f"\nConfig values (from job parameters / scope fallback):")
+for field in ("account_id", "client_id", "sql_warehouse_id", "analysis_schema_name", "use_sp_auth"):
+    v = json_.get(field, "<not set>")
+    display_v = f"{str(v)[:4]}...{str(v)[-4:]}" if v and len(str(v)) > 8 else v
+    print(f"  {field}: {display_v}")
 
 
 # COMMAND ----------
@@ -157,7 +169,9 @@ def getAWSTokenwithOAuth(source, baccount, client_id, client_secret):
 
 # COMMAND ----------
 
-token = getAWSTokenwithOAuth(workspaceUrl,False, dbutils.secrets.get(scope=json_['master_name_scope'], key='client-id'), dbutils.secrets.get(scope=json_['master_name_scope'], key='client-secret'))
+token = getAWSTokenwithOAuth(workspaceUrl, False,
+    json_.get("client_id") or dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("client_id", "client-id")),
+    dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("client_secret", "client-secret")))
 
 print("Workspace token obtained" if token else "Workspace token FAILED")
 
@@ -197,7 +211,11 @@ print(response.json())
 
 # COMMAND ----------
 
-access_token = getAWSTokenwithOAuth(dbutils.secrets.get(scope=json_['master_name_scope'], key='account-console-id'),True, dbutils.secrets.get(scope=json_['master_name_scope'], key='client-id'), dbutils.secrets.get(scope=json_['master_name_scope'], key='client-secret'))
+access_token = getAWSTokenwithOAuth(
+    json_.get("account_id") or dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("account_id", "account-console-id")),
+    True,
+    json_.get("client_id") or dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("client_id", "client-id")),
+    dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("client_secret", "client-secret")))
 
 print("Account token obtained" if access_token else "Account token FAILED")
 
@@ -213,7 +231,7 @@ print("Account token obtained" if access_token else "Account token FAILED")
 
 import requests
 
-DATABRICKS_ACCOUNT_ID = dbutils.secrets.get(scope=sat_scope, key="account-console-id")
+DATABRICKS_ACCOUNT_ID = json_.get("account_id") or dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("account_id", "account-console-id"))
 url = f'https://accounts.cloud.databricks.us/api/2.0/accounts/{DATABRICKS_ACCOUNT_ID}/workspaces'
 
 ## Note: The access token must be generated for a Service Principal that has account admin privileges to run this command.

--- a/notebooks/diagnosis/sat_diagnosis_azure.py
+++ b/notebooks/diagnosis/sat_diagnosis_azure.py
@@ -61,16 +61,18 @@ if not found:
 # COMMAND ----------
 
 try:
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='account-console-id')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='sql-warehouse-id')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='subscription-id')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='tenant-id')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='client-id')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='client-secret')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key="analysis_schema_name")
-   print("Your SAT configuration has required secret names")
+   assert json_.get('account_id'), "account_id missing"
+   assert json_.get('client_id'), "client_id missing"
+   assert json_.get('tenant_id'), "tenant_id missing"
+   assert json_.get('subscription_id'), "subscription_id missing"
+   _sat_scope = json_.get("secret_scope", json_['master_name_scope'])
+   _sat_keys  = json_.get("secret_keys", DEFAULT_SECRET_KEYS)
+   dbutils.secrets.get(scope=_sat_scope, key=_sat_keys.get("client_secret", "client-secret"))
+   assert json_.get('sql_warehouse_id'), "sql_warehouse_id missing"
+   assert json_.get('analysis_schema_name'), "analysis_schema_name missing"
+   print("Your SAT configuration has all required values")
 except Exception as e:
-   dbutils.notebook.exit(f'Your SAT configuration is missing required secret, please review setup instructions {e}')  
+   dbutils.notebook.exit(f'Your SAT configuration is missing a required value, please review setup instructions: {e}')
 
 # COMMAND ----------
 
@@ -79,12 +81,24 @@ except Exception as e:
 
 # COMMAND ----------
 
-sat_scope = json_['master_name_scope']
+sat_scope = json_.get("secret_scope", json_['master_name_scope'])
+_sat_keys = json_.get("secret_keys", DEFAULT_SECRET_KEYS)
 
+print(f"Secret scope: {sat_scope}")
+print("Keys present in scope:")
 for key in dbutils.secrets.list(sat_scope):
-    print(key.key)
-    secretvalue = dbutils.secrets.get(scope=sat_scope, key=key.key)
-    print(secretvalue)
+    try:
+        val = dbutils.secrets.get(scope=sat_scope, key=key.key)
+        print(f"  {key.key}: {'[set, {0} chars]'.format(len(val)) if val else '[empty]'}")
+    except Exception as e:
+        print(f"  {key.key}: [error reading: {e}]")
+
+print(f"\nConfig values (from job parameters / scope fallback):")
+for field in ("account_id", "client_id", "tenant_id", "subscription_id",
+              "sql_warehouse_id", "analysis_schema_name"):
+    v = json_.get(field, "<not set>")
+    display_v = f"{str(v)[:4]}...{str(v)[-4:]}" if v and len(str(v)) > 8 else v
+    print(f"  {field}: {display_v}")
 
 
 # COMMAND ----------
@@ -96,15 +110,15 @@ for key in dbutils.secrets.list(sat_scope):
 
 import msal
 
-# Define Azure AD constants
-TENANT_ID = dbutils.secrets.get(scope=sat_scope, key="tenant-id")
-CLIENT_ID = dbutils.secrets.get(scope=sat_scope, key="client-id") 
+# Define Azure AD constants — prefer json_ values (set by initialize.py).
+TENANT_ID = json_.get("tenant_id") or dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("tenant_id", "tenant-id"))
+CLIENT_ID = json_.get("client_id") or dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("client_id", "client-id"))
 AUTHORITY = "https://login.microsoftonline.com/" + TENANT_ID
 
 app = msal.ConfidentialClientApplication(
     client_id=CLIENT_ID,
     authority=AUTHORITY,
-    client_credential=(dbutils.secrets.get(scope=sat_scope, key="client-secret"))
+    client_credential=dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("client_secret", "client-secret"))
 )
 
 # Acquire token for managed identity
@@ -167,7 +181,7 @@ print(response.json())
 
 import requests
 
-DATABRICKS_ACCOUNT_ID = dbutils.secrets.get(scope=sat_scope, key="account-console-id")
+DATABRICKS_ACCOUNT_ID = json_.get("account_id") or dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("account_id", "account-console-id"))
 url = f'https://accounts.azuredatabricks.net/api/2.0/accounts/{DATABRICKS_ACCOUNT_ID}/workspaces'
 
 ## Note: The access token must be generated for a Service Principal that has account admin privileges to run this command.  
@@ -194,13 +208,13 @@ def get_msal_token():
     """
     validate client id and secret from microsoft and google
     """
-    # Define Azure AD constants
-    TENANT_ID = dbutils.secrets.get(scope=sat_scope, key="tenant-id")
-    CLIENT_ID = dbutils.secrets.get(scope=sat_scope, key="client-id") 
+    # Define Azure AD constants — prefer json_ values (set by initialize.py).
+    TENANT_ID = json_.get("tenant_id") or dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("tenant_id", "tenant-id"))
+    CLIENT_ID = json_.get("client_id") or dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("client_id", "client-id"))
     try:
         app = msal.ConfidentialClientApplication(
             client_id=CLIENT_ID,
-            client_credential=(dbutils.secrets.get(scope=sat_scope, key="client-secret")),
+            client_credential=dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("client_secret", "client-secret")),
             authority=f"https://login.microsoftonline.com/{TENANT_ID}",
         )
         # call for default scope in order to verify client id and secret.

--- a/notebooks/diagnosis/sat_diagnosis_gcp.py
+++ b/notebooks/diagnosis/sat_diagnosis_gcp.py
@@ -62,15 +62,16 @@ if not found:
 
 
 try:
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='account-console-id')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='sql-warehouse-id')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='client-id')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='client-secret')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key='use-sp-auth')
-   dbutils.secrets.get(scope=json_['master_name_scope'], key="analysis_schema_name")
-   print("Your SAT configuration is has required secret names")
+   assert json_.get('account_id'), "account_id missing"
+   assert json_.get('use_sp_auth') or json_.get('client_id'), "client_id/use_sp_auth missing"
+   _sat_scope = json_.get("secret_scope", json_['master_name_scope'])
+   _sat_keys  = json_.get("secret_keys", DEFAULT_SECRET_KEYS)
+   dbutils.secrets.get(scope=_sat_scope, key=_sat_keys.get("client_secret", "client-secret"))
+   assert json_.get('sql_warehouse_id'), "sql_warehouse_id missing"
+   assert json_.get('analysis_schema_name'), "analysis_schema_name missing"
+   print("Your SAT configuration has all required values")
 except Exception as e:
-   dbutils.notebook.exit(f'Your SAT configuration is missing required secret, please review setup instructions {e}')  
+   dbutils.notebook.exit(f'Your SAT configuration is missing a required value, please review setup instructions: {e}')
 
 # COMMAND ----------
 
@@ -79,12 +80,23 @@ except Exception as e:
 
 # COMMAND ----------
 
-sat_scope = json_['master_name_scope']
+sat_scope = json_.get("secret_scope", json_['master_name_scope'])
+_sat_keys = json_.get("secret_keys", DEFAULT_SECRET_KEYS)
 
+print(f"Secret scope: {sat_scope}")
+print("Keys present in scope:")
 for key in dbutils.secrets.list(sat_scope):
-    print(key.key)
-    secretvalue = dbutils.secrets.get(scope=sat_scope, key=key.key)
-    print(secretvalue)
+    try:
+        val = dbutils.secrets.get(scope=sat_scope, key=key.key)
+        print(f"  {key.key}: {'[set, {0} chars]'.format(len(val)) if val else '[empty]'}")
+    except Exception as e:
+        print(f"  {key.key}: [error reading: {e}]")
+
+print(f"\nConfig values (from job parameters / scope fallback):")
+for field in ("account_id", "client_id", "sql_warehouse_id", "analysis_schema_name", "use_sp_auth"):
+    v = json_.get(field, "<not set>")
+    display_v = f"{str(v)[:4]}...{str(v)[-4:]}" if v and len(str(v)) > 8 else v
+    print(f"  {field}: {display_v}")
 
 
 # COMMAND ----------
@@ -128,7 +140,9 @@ def getGCPTokenwithOAuth(source, baccount, client_id, client_secret):
 
 # COMMAND ----------
 
-token = getGCPTokenwithOAuth(workspaceUrl,False, dbutils.secrets.get(scope=json_['master_name_scope'], key='client-id'), dbutils.secrets.get(scope=json_['master_name_scope'], key='client-secret'))
+token = getGCPTokenwithOAuth(workspaceUrl, False,
+    json_.get("client_id") or dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("client_id", "client-id")),
+    dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("client_secret", "client-secret")))
 
 print("Workspace token obtained" if token else "Workspace token FAILED")
 
@@ -169,7 +183,11 @@ print(response.json())
 
 # COMMAND ----------
 
-access_token = getGCPTokenwithOAuth(dbutils.secrets.get(scope=json_['master_name_scope'], key='account-console-id'),True, dbutils.secrets.get(scope=json_['master_name_scope'], key='client-id'), dbutils.secrets.get(scope=json_['master_name_scope'], key='client-secret'))
+access_token = getGCPTokenwithOAuth(
+    json_.get("account_id") or dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("account_id", "account-console-id")),
+    True,
+    json_.get("client_id") or dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("client_id", "client-id")),
+    dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("client_secret", "client-secret")))
 
 print("Account token obtained" if access_token else "Account token FAILED")
 
@@ -185,7 +203,7 @@ print("Account token obtained" if access_token else "Account token FAILED")
 
 import requests
 
-DATABRICKS_ACCOUNT_ID = dbutils.secrets.get(scope=sat_scope, key="account-console-id")
+DATABRICKS_ACCOUNT_ID = json_.get("account_id") or dbutils.secrets.get(scope=sat_scope, key=_sat_keys.get("account_id", "account-console-id"))
 url = f'https://accounts.gcp.databricks.com/api/2.0/accounts/{DATABRICKS_ACCOUNT_ID}/workspaces'
 
 ## Note: The access token must be generated for a Service Principal that has account admin privileges to run this command.  

--- a/notebooks/permission_analysis_data_collection.py
+++ b/notebooks/permission_analysis_data_collection.py
@@ -393,18 +393,30 @@ SP_CREDENTIALS['cloud_type'] = cloud_type
 
 print(f"\n1. Loading Service Principal Credentials...")
 
-# Get the secrets scope name (default: "sat_scope" for SAT integration)
-secrets_scope = SECRETS_SCOPE if 'SECRETS_SCOPE' in dir() else "sat_scope"
+# Get the secrets scope and key map from SAT configuration (set by initialize.py
+# via %run ./brickhound/00_config which %runs ../Utils/initialize).
+# Fall back to sat_scope / default keys for standalone notebook runs.
+secrets_scope = json_.get("secret_scope", SECRETS_SCOPE if 'SECRETS_SCOPE' in dir() else "sat_scope")
+_secret_keys  = json_.get("secret_keys",  DEFAULT_SECRET_KEYS if 'DEFAULT_SECRET_KEYS' in dir() else {
+    "account_id": "account-console-id", "client_id": "client-id",
+    "client_secret": "client-secret", "tenant_id": "tenant-id",
+})
 
 try:
-    # Updated for SAT integration: using SAT secret key names
-    SP_CREDENTIALS['account_id'] = dbutils.secrets.get(scope=secrets_scope, key="account-console-id")
-    SP_CREDENTIALS['client_id'] = dbutils.secrets.get(scope=secrets_scope, key="client-id")
-    SP_CREDENTIALS['client_secret'] = dbutils.secrets.get(scope=secrets_scope, key="client-secret")
+    # Non-secret config: prefer values already in json_ (populated by initialize.py
+    # via param->scope resolution); fall back to scope read for standalone runs.
+    SP_CREDENTIALS['account_id'] = json_.get("account_id") or dbutils.secrets.get(
+        scope=secrets_scope, key=_secret_keys.get("account_id", "account-console-id"))
+    SP_CREDENTIALS['client_id']  = json_.get("client_id") or dbutils.secrets.get(
+        scope=secrets_scope, key=_secret_keys.get("client_id", "client-id"))
+    # client_secret is always scope-only — never in json_ / params.
+    SP_CREDENTIALS['client_secret'] = dbutils.secrets.get(
+        scope=secrets_scope, key=_secret_keys.get("client_secret", "client-secret"))
 
     # Try to load tenant_id for Azure (optional for AWS/GCP)
     try:
-        SP_CREDENTIALS['tenant_id'] = dbutils.secrets.get(scope=secrets_scope, key="tenant-id")
+        SP_CREDENTIALS['tenant_id'] = json_.get("tenant_id") or dbutils.secrets.get(
+            scope=secrets_scope, key=_secret_keys.get("tenant_id", "tenant-id"))
         print(f"   ✓ Loaded tenant-id for Azure authentication")
     except Exception:
         # tenant_id not required for AWS/GCP, only log for debugging

--- a/notebooks/security_analysis_initializer.py
+++ b/notebooks/security_analysis_initializer.py
@@ -33,7 +33,10 @@ cloud_type = getCloudType(hostname)
 # COMMAND ----------
 
 def run_notebook(notebook_path, timeout):
-    status = dbutils.notebook.run(notebook_path, timeout)
+    # SAT_CHILD_PARAMS is defined by %run ./Utils/initialize above.
+    # dbutils.notebook.run() creates an isolated widget context — the child
+    # does NOT inherit the parent's widgets, so all values must be forwarded.
+    status = dbutils.notebook.run(notebook_path, timeout, SAT_CHILD_PARAMS)
     if status != "OK":
         loggr.exception(f"Error Encountered in {notebook_path}", status)
         dbutils.notebook.exit()

--- a/terraform/aws/TERRAFORM_AWS.md
+++ b/terraform/aws/TERRAFORM_AWS.md
@@ -153,7 +153,24 @@ Supplemental Documentation:
 
 Additional Considerations:
 
-Your jobs may fail if there was a pre-existing secret scope named sat_scope when you run terraform apply. To remedy this, you will need to change the name of your secret scope in secrets.tf, re-run terraform apply, and then navigate to Workspace -> Applications -> SAT-TF ->/notebooks/Utils/initialize and change the secret scope name in  6 places (3 times in CMD 4 and 3 times in CMD 5). You then can re-run your failed jobs.
+**Using a custom or pre-existing secret scope:**
+
+Set `secret_scope_name` in `terraform.tfvars` to use a different scope name (e.g. for multiple SAT instances):
+
+```hcl
+secret_scope_name = "sat_scope_prod"
+```
+
+To bring a pre-existing scope that SAT should not write into, set `manage_secrets = false`. SAT validates the required `client-secret` key is readable and passes all other config as direct job parameters:
+
+```hcl
+manage_secrets = false
+secret_scope_name = "my-existing-scope"
+# Optional: override specific key names if yours differ from SAT defaults
+# secret_key_names = { client_secret = "my-sp-client-secret" }
+```
+
+See the [Secret Scope Reference](https://databricks-industry-solutions.github.io/security-analysis-tool/docs/installation/secret-scope) for the full list of required keys and ACL requirements.
 
 If `terraform apply` fails with `An app with the same name already exists` for `sat-permissions-exp` (typically because BrickHound was previously deployed via the DABS installer or a prior Terraform state was lost), import the existing app into Terraform state and re-apply:
 

--- a/terraform/aws/provider.tf
+++ b/terraform/aws/provider.tf
@@ -23,6 +23,12 @@ module "common" {
   proxies                         = var.proxies
   run_on_serverless               = var.run_on_serverless
   secret_scope_name               = var.secret_scope_name
+  manage_secrets                  = var.manage_secrets
+  secret_key_names                = var.secret_key_names
+  app_config_scope_name           = var.app_config_scope_name
+  scope_provided_keys             = var.scope_provided_keys
+  client_id                       = var.client_id
+  use_sp_auth                     = var.use_sp_auth
   secrets_scanner_cron_expression = var.secrets_scanner_cron_expression
   driver_cron_expression          = var.driver_cron_expression
   job_compute_num_workers         = var.job_compute_num_workers

--- a/terraform/aws/secrets.tf
+++ b/terraform/aws/secrets.tf
@@ -1,31 +1,12 @@
 ### AWS Specific Secrets
-
-resource "databricks_secret" "user" {
-  key          = "user"
-  string_value = var.account_user
-  scope        = module.common.secret_scope_id
-}
-
-resource "databricks_secret" "pass" {
-  key          = "pass"
-  string_value = var.account_pass
-  scope        = module.common.secret_scope_id
-}
-
-resource "databricks_secret" "use_sp_auth" {
-  key          = "use-sp-auth"
-  string_value = var.use_sp_auth
-  scope        = module.common.secret_scope_id
-}
-
-resource "databricks_secret" "client_id" {
-  key          = "client-id"
-  string_value = var.client_id
-  scope        = module.common.secret_scope_id
-}
+#
+# Only the credential secret is stored in the scope. All other values
+# (account_id, client_id, use_sp_auth, etc.) are passed as direct job
+# base_parameters via locals.sat_base_parameters and never need to be secrets.
 
 resource "databricks_secret" "client_secret" {
-  key          = "client-secret"
+  count        = var.manage_secrets ? 1 : 0
+  key          = module.common.secret_keys_resolved["client_secret"]
   string_value = var.client_secret
   scope        = module.common.secret_scope_id
 }

--- a/terraform/aws/template.tfvars
+++ b/terraform/aws/template.tfvars
@@ -42,4 +42,30 @@ run_on_serverless = false # [Only monitor current workspace]
 # Example: "sat_scope_prod" or "sat_scope_scan1"
 # secret_scope_name = "sat_scope"
 
+# Bring Your Own Secret Scope (Optional)
+# Set manage_secrets = false if you have a pre-existing secret scope that SAT should read from
+# instead of creating its own. SAT will only write the client_secret key (the only true credential).
+# When false, ensure the scope exists and the client_secret key is readable by the SAT service principal.
+# manage_secrets = true
+
+# Secret Key Name Overrides (Optional)
+# If your existing scope uses different key names, map logical names to physical names.
+# Only specify the keys you want to override; unspecified keys use SAT defaults.
+# Example: { client_secret = "my-sp-client-secret" }
+# secret_key_names = {}
+
+# App Config Scope (Optional — only relevant when manage_secrets = false)
+# When manage_secrets=false, SAT still needs to write analysis_schema_name and sql-warehouse-id
+# to *some* scope for the BrickHound Databricks App to read via valueFrom.
+# Leave blank to have SAT create a dedicated "sat_app_scope", or specify an existing scope name.
+# app_config_scope_name = ""
+
 #Flag to scan for hardcoded secrets in all the SAT configured workspace notebooks
+
+# Pre-existing scope keys (Optional — only relevant when manage_secrets = false)
+# List the logical names of values that are already in your scope.
+# SAT will not write them and the BrickHound app binding will point at your scope.
+# Supported: client_secret, account_id, client_id, tenant_id, subscription_id,
+#            proxies, analysis_schema_name
+# Example: scope_provided_keys = ["client_secret", "analysis_schema_name"]
+# scope_provided_keys = []

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -29,19 +29,25 @@ variable "secret_scope_name" {
   default     = "sat_scope"
 }
 
+variable "manage_secrets" {
+  type        = bool
+  description = "When true (default), SAT creates the secret scope and writes the client_secret. Set to false to bring a pre-existing scope."
+  default     = true
+}
+
+variable "secret_key_names" {
+  type        = map(string)
+  description = "Override map from logical key name to physical secret key name."
+  default     = {}
+}
+
+variable "app_config_scope_name" {
+  type        = string
+  description = "Secret scope for BrickHound app valueFrom bindings. Defaults to secret_scope_name."
+  default     = ""
+}
+
 ### AWS Specific Variables
-
-variable "account_user" {
-  description = "Account Console Username"
-  type        = string
-  default     = " "
-}
-
-variable "account_pass" {
-  description = "Account Console Password"
-  type        = string
-  default     = " "
-}
 
 variable "use_sp_auth" {
   description = "Authenticate with Service Principal OAuth tokens instead of user and password"
@@ -117,3 +123,9 @@ variable "job_schedule_timezone_id" {
   }
 }
 
+
+variable "scope_provided_keys" {
+  type        = list(string)
+  description = "Logical key names pre-populated in the user's existing scope. Mirrors the DABS scope_contains checkbox. SAT will not write these keys and the app binding uses the user's scope directly."
+  default     = []
+}

--- a/terraform/azure/TERRAFORM_Azure.md
+++ b/terraform/azure/TERRAFORM_Azure.md
@@ -151,11 +151,23 @@ GRANT SELECT ON TABLE `<catalog>`.`<schema>`.brickhound_collection_metadata TO `
 
 ### Additional Considerations:
 
-* If a pre-existing secret scope named `sat_scope` causes jobs to fail:
-1. Rename the secret scope in `secrets.tf`
-2. Re-run `terraform apply`.
-3. Update the secret scope name in 6 locations (`CMD 4` and `CMD 5`) of `Workspace -> Applications -> SAT-TF/notebooks/Utils/initialize`.
-4. Re-run failed jobs
+**Using a custom or pre-existing secret scope:**
+
+Set `secret_scope_name` in `terraform.tfvars` to use a different scope name:
+
+```hcl
+secret_scope_name = "sat_scope_prod"
+```
+
+To bring a pre-existing scope, set `manage_secrets = false`:
+
+```hcl
+manage_secrets = false
+secret_scope_name = "my-existing-scope"
+# secret_key_names = { client_secret = "my-sp-client-secret" }
+```
+
+See the [Secret Scope Reference](https://databricks-industry-solutions.github.io/security-analysis-tool/docs/installation/secret-scope) for the full list of required keys and ACL requirements.
 
 * If `terraform apply` fails with `An app with the same name already exists` for `sat-permissions-exp` (typically because BrickHound was previously deployed via the DABS installer or a prior Terraform state was lost), import the existing app into Terraform state and re-apply:
 

--- a/terraform/azure/provider.tf
+++ b/terraform/azure/provider.tf
@@ -21,6 +21,13 @@ module "common" {
   proxies                         = var.proxies
   run_on_serverless               = var.run_on_serverless
   secret_scope_name               = var.secret_scope_name
+  manage_secrets                  = var.manage_secrets
+  secret_key_names                = var.secret_key_names
+  app_config_scope_name           = var.app_config_scope_name
+  scope_provided_keys             = var.scope_provided_keys
+  client_id                       = var.client_id
+  tenant_id                       = var.tenant_id
+  subscription_id                 = var.subscription_id
   secrets_scanner_cron_expression = var.secrets_scanner_cron_expression
   driver_cron_expression          = var.driver_cron_expression
   job_compute_num_workers         = var.job_compute_num_workers

--- a/terraform/azure/secrets.tf
+++ b/terraform/azure/secrets.tf
@@ -1,25 +1,12 @@
 ### Azure Specific Secrets
+#
+# Only the credential secret is stored in the scope. All other values
+# (client_id, tenant_id, subscription_id, etc.) are passed as direct job
+# base_parameters via locals.sat_base_parameters and never need to be secrets.
 
 resource "databricks_secret" "client_secret" {
-  key          = "client-secret"
+  count        = var.manage_secrets ? 1 : 0
+  key          = module.common.secret_keys_resolved["client_secret"]
   string_value = var.client_secret
-  scope        = module.common.secret_scope_id
-}
-
-resource "databricks_secret" "subscription_id" {
-  key          = "subscription-id"
-  string_value = var.subscription_id
-  scope        = module.common.secret_scope_id
-}
-
-resource "databricks_secret" "tenant_id" {
-  key          = "tenant-id"
-  string_value = var.tenant_id
-  scope        = module.common.secret_scope_id
-}
-
-resource "databricks_secret" "client_id" {
-  key          = "client-id"
-  string_value = var.client_id
   scope        = module.common.secret_scope_id
 }

--- a/terraform/azure/template.tfvars
+++ b/terraform/azure/template.tfvars
@@ -43,3 +43,24 @@ run_on_serverless = false # [Only monitor current workspace]
 # Customize to use a different scope name (useful for multiple SAT instances or naming conventions)
 # Example: "sat_scope_prod" or "sat_scope_scan1"
 # secret_scope_name = "sat_scope"
+
+# Bring Your Own Secret Scope (Optional)
+# Set manage_secrets = false if you have a pre-existing secret scope that SAT should read from.
+# SAT will only write the client_secret key (the only true credential).
+# manage_secrets = true
+
+# Secret Key Name Overrides (Optional)
+# Map logical names to physical names for keys in your existing scope.
+# Example: { client_secret = "my-sp-client-secret" }
+# secret_key_names = {}
+
+# App Config Scope (Optional — only relevant when manage_secrets = false)
+# Scope for BrickHound app valueFrom bindings (analysis_schema_name, sql-warehouse-id).
+# app_config_scope_name = ""
+# Pre-existing scope keys (Optional — only relevant when manage_secrets = false)
+# List the logical names of values that are already in your scope.
+# SAT will not write them and the BrickHound app binding will point at your scope.
+# Supported: client_secret, account_id, client_id, tenant_id, subscription_id,
+#            proxies, analysis_schema_name
+# Example: scope_provided_keys = ["client_secret", "analysis_schema_name"]
+# scope_provided_keys = []

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -29,6 +29,24 @@ variable "secret_scope_name" {
   default     = "sat_scope"
 }
 
+variable "manage_secrets" {
+  type        = bool
+  description = "When true (default), SAT creates the secret scope and writes the client_secret. Set to false to bring a pre-existing scope."
+  default     = true
+}
+
+variable "secret_key_names" {
+  type        = map(string)
+  description = "Override map from logical key name to physical secret key name."
+  default     = {}
+}
+
+variable "app_config_scope_name" {
+  type        = string
+  description = "Secret scope for BrickHound app valueFrom bindings. Defaults to secret_scope_name."
+  default     = ""
+}
+
 variable "analysis_schema_name" {
   type        = string
   description = "Name of the schema to be used for analysis"
@@ -107,4 +125,9 @@ variable "job_schedule_timezone_id" {
     condition     = can(regex("^([A-Za-z]+(/[A-Za-z0-9_+\\-]+)+|UTC)$", var.job_schedule_timezone_id))
     error_message = "Must be a valid IANA time zone ID (e.g. America/New_York, Etc/UTC) or UTC."
   }
+}
+variable "scope_provided_keys" {
+  type        = list(string)
+  description = "Logical key names pre-populated in the user's existing scope. Mirrors the DABS scope_contains checkbox. SAT will not write these keys and the app binding uses the user's scope directly."
+  default     = []
 }

--- a/terraform/common/brickhound_app.tf
+++ b/terraform/common/brickhound_app.tf
@@ -12,20 +12,20 @@ resource "databricks_app" "brickhound" {
     {
       name = "analysis_schema_name"
       secret = {
-        scope      = databricks_secret_scope.sat.id
-        key        = "analysis_schema_name"
+        # When the user pre-populated analysis_schema_name in their own scope
+        # (scope_provided_keys contains "analysis_schema_name"), bind directly
+        # to that scope so SAT never writes to it.  Otherwise use the app
+        # config scope SAT owns.
+        scope      = contains(var.scope_provided_keys, "analysis_schema_name") ? var.secret_scope_name : local.resolved_app_config_scope
+        key        = local.secret_keys["analysis_schema_name"]
         permission = "READ"
       }
     },
     {
-      name = "sql-warehouse-id"
-      secret = {
-        scope      = databricks_secret_scope.sat.id
-        key        = "sql-warehouse-id"
-        permission = "READ"
-      }
-    },
-    {
+      # WAREHOUSE_ID env var resolves from the sql_warehouse resource below.
+      # A secret is no longer needed — valueFrom: "warehouse" in app.yaml
+      # returns the warehouse ID directly from the sql_warehouse resource,
+      # so the granted warehouse and the queried warehouse are always the same.
       name = "warehouse"
       sql_warehouse = {
         id         = var.sqlw_id == "new" ? databricks_sql_endpoint.new[0].id : data.databricks_sql_warehouse.old[0].id

--- a/terraform/common/brickhound_denylist_candidates_job.tf
+++ b/terraform/common/brickhound_denylist_candidates_job.tf
@@ -56,10 +56,10 @@ resource "databricks_job" "brickhound_denylist_candidates" {
     notebook_task {
       notebook_path = "${databricks_repo.security_analysis_tool.path}/notebooks/brickhound/07_denylist_candidates"
 
-      base_parameters = {
+      base_parameters = merge(local.sat_base_parameters, {
         inactive_days = "90"
         min_inactive  = "1"
-      }
+      })
     }
 
     timeout_seconds = 3600 # 1 hour

--- a/terraform/common/brickhound_job.tf
+++ b/terraform/common/brickhound_job.tf
@@ -55,7 +55,8 @@ resource "databricks_job" "brickhound_data_collection" {
     environment_key = var.run_on_serverless ? "default" : null
 
     notebook_task {
-      notebook_path = "${databricks_repo.security_analysis_tool.path}/notebooks/permission_analysis_data_collection"
+      notebook_path   = "${databricks_repo.security_analysis_tool.path}/notebooks/permission_analysis_data_collection"
+      base_parameters = local.sat_base_parameters
     }
 
     timeout_seconds = 14400 # 4 hours max (permissions collection can take time for large accounts)

--- a/terraform/common/brickhound_privileged_non_idp_job.tf
+++ b/terraform/common/brickhound_privileged_non_idp_job.tf
@@ -59,11 +59,11 @@ resource "databricks_job" "brickhound_privileged_non_idp" {
 
       # Detection-only by default. Set remediate=yes deliberately to enable
       # continuous auto-removal of privileged roles from non-IdP identities.
-      base_parameters = {
+      base_parameters = merge(local.sat_base_parameters, {
         finding_types       = "account_admin,workspace_admin"
         include_idp_managed = "no"
         remediate           = "no"
-      }
+      })
     }
 
     timeout_seconds = 3600 # 1 hour

--- a/terraform/common/brickhound_share_to_account_job.tf
+++ b/terraform/common/brickhound_share_to_account_job.tf
@@ -60,11 +60,11 @@ resource "databricks_job" "brickhound_share_to_account" {
 
       # Detection-only by default. Set remediate=yes deliberately to enable
       # continuous auto-removal of the "account users" ACL entry.
-      base_parameters = {
+      base_parameters = merge(local.sat_base_parameters, {
         last_n_days    = "30"
         resource_types = "dashboards,genie,apps"
         remediate      = "no"
-      }
+      })
     }
 
     timeout_seconds = 3600 # 1 hour

--- a/terraform/common/jobs.tf
+++ b/terraform/common/jobs.tf
@@ -53,7 +53,8 @@ resource "databricks_job" "initializer" {
       }
     }
     notebook_task {
-      notebook_path = "${databricks_repo.security_analysis_tool.path}/notebooks/security_analysis_initializer"
+      notebook_path   = "${databricks_repo.security_analysis_tool.path}/notebooks/security_analysis_initializer"
+      base_parameters = local.sat_base_parameters
     }
   }
 
@@ -114,7 +115,8 @@ resource "databricks_job" "driver" {
       }
     }
     notebook_task {
-      notebook_path = "${databricks_repo.security_analysis_tool.path}/notebooks/security_analysis_driver"
+      notebook_path   = "${databricks_repo.security_analysis_tool.path}/notebooks/security_analysis_driver"
+      base_parameters = local.sat_base_parameters
     }
   }
 
@@ -185,7 +187,8 @@ resource "databricks_job" "secrets_scanner" {
       }
     }
     notebook_task {
-      notebook_path = "${databricks_repo.security_analysis_tool.path}/notebooks/security_analysis_secrets_scanner"
+      notebook_path   = "${databricks_repo.security_analysis_tool.path}/notebooks/security_analysis_secrets_scanner"
+      base_parameters = local.sat_base_parameters
     }
   }
 

--- a/terraform/common/locals.tf
+++ b/terraform/common/locals.tf
@@ -1,0 +1,64 @@
+locals {
+  # Resolved key names: DEFAULT_SECRET_KEYS merged with per-user overrides.
+  # Only the credential secret (client_secret) and the PAT prefix need to live
+  # in a secret scope; all other values are passed as direct job base_parameters.
+  secret_keys = merge(
+    {
+      client_secret              = "client-secret"
+      workspace_pat_token_prefix = "sat-token"
+      # Legacy keys — present here so BYO users who override one entry don't have
+      # to re-specify the others; these are NOT written to the scope for new installs.
+      account_id           = "account-console-id"
+      sql_warehouse_id     = "sql-warehouse-id"
+      analysis_schema_name = "analysis_schema_name"
+      proxies              = "proxies"
+      use_sp_auth          = "use-sp-auth"
+      client_id            = "client-id"
+      tenant_id            = "tenant-id"
+      subscription_id      = "subscription-id"
+    },
+    var.secret_key_names
+  )
+
+  # For `manage_secrets = false` we reference the scope by name only
+  # (the provider has no data source for existing scopes; a scope's TF id is its name).
+  scope_ref = var.manage_secrets ? databricks_secret_scope.sat[0].id : var.secret_scope_name
+
+  # App config scope: holds analysis_schema_name for the BrickHound App
+  # valueFrom binding (BRICKHOUND_SCHEMA env var).
+  # WAREHOUSE_ID now resolves from the sql_warehouse resource directly.
+  #
+  # Resolution order (mirrors dabs/sat/config.py:_resolve_app_config_scope):
+  #   1. analysis_schema_name in scope_provided_keys  -> secret_scope_name
+  #      (key already in user's scope; app binds there directly, no new scope)
+  #   2. manage_secrets = true, no provided key       -> secret_scope_name
+  #   3. explicit app_config_scope_name               -> use it
+  #   4. fallback                                     -> "sat_app_scope"
+  resolved_app_config_scope = (
+    contains(var.scope_provided_keys, "analysis_schema_name")
+    ? var.secret_scope_name
+    : var.manage_secrets
+      ? var.secret_scope_name
+      : var.app_config_scope_name != ""
+        ? var.app_config_scope_name
+        : "sat_app_scope"
+  )
+
+  # Create the app config scope whenever it differs from the main scope.
+  create_app_scope = local.resolved_app_config_scope != var.secret_scope_name
+
+  # Base parameters injected into every SAT notebook_task.
+  # Non-secret config values travel here; client_secret stays scope-only.
+  sat_base_parameters = {
+    secret_scope              = var.secret_scope_name
+    secret_key_names          = jsonencode(var.secret_key_names)
+    account_id_param          = var.account_console_id
+    client_id_param           = var.client_id
+    tenant_id_param           = var.tenant_id
+    subscription_id_param     = var.subscription_id
+    sql_warehouse_id_param    = var.sqlw_id == "new" ? "" : var.sqlw_id
+    analysis_schema_name_param = var.analysis_schema_name
+    proxies_param             = jsonencode(var.proxies)
+    use_sp_auth_param         = tostring(var.use_sp_auth)
+  }
+}

--- a/terraform/common/outputs.tf
+++ b/terraform/common/outputs.tf
@@ -1,4 +1,21 @@
 output "secret_scope_id" {
-  value       = databricks_secret_scope.sat.id
-  description = "ID of the created secret scope to add more secrets if necessary"
+  value       = var.manage_secrets ? databricks_secret_scope.sat[0].id : var.secret_scope_name
+  description = "ID/name of the SAT secret scope (created or pre-existing)"
 }
+
+output "app_config_scope_id" {
+  value       = local.resolved_app_config_scope
+  description = "Name/ID of the scope used for BrickHound app valueFrom bindings"
+}
+
+output "secret_keys_resolved" {
+  value       = local.secret_keys
+  description = "Resolved logical->physical secret key name map (defaults merged with overrides)"
+}
+
+output "sat_base_parameters" {
+  value       = local.sat_base_parameters
+  description = "Base parameters map injected into every SAT notebook_task"
+  sensitive   = false
+}
+

--- a/terraform/common/secrets.tf
+++ b/terraform/common/secrets.tf
@@ -1,5 +1,6 @@
 resource "databricks_secret_scope" "sat" {
-  name = var.secret_scope_name
+  count = var.manage_secrets ? 1 : 0
+  name  = var.secret_scope_name
 }
 
 # Explicit ACLs on the SAT secret scope.
@@ -13,44 +14,44 @@ resource "databricks_secret_scope" "sat" {
 # backed scopes and cannot be restricted via ACL. Deploy SAT in a workspace
 # whose admin membership is already tightly controlled.
 resource "databricks_secret_acl" "sat_scope_owner" {
+  count      = var.manage_secrets ? 1 : 0
   principal  = data.databricks_current_user.me.user_name
   permission = "MANAGE"
-  scope      = databricks_secret_scope.sat.id
+  scope      = databricks_secret_scope.sat[0].id
 }
 
 resource "databricks_secret_acl" "sat_scope_readers" {
-  for_each   = toset(var.sat_authorized_principals)
+  for_each   = var.manage_secrets ? toset(var.sat_authorized_principals) : toset([])
   principal  = each.value
   permission = "READ"
-  scope      = databricks_secret_scope.sat.id
+  scope      = databricks_secret_scope.sat[0].id
 }
 
-resource "databricks_secret" "user_email" {
-  key          = "user-email-for-alerts"
-  string_value = var.notification_email == "" ? data.databricks_current_user.me.user_name : var.notification_email
-  scope        = databricks_secret_scope.sat.id
+# App config scope for BrickHound Databricks App valueFrom bindings.
+# Holds only analysis_schema_name + sql-warehouse-id (non-credential config).
+# Created separately so manage_secrets=false users keep their credential scope
+# pristine while SAT still manages the app config entries.
+resource "databricks_secret_scope" "sat_app_config" {
+  count = local.create_app_scope ? 1 : 0
+  # Use the fully-resolved name, not the raw var which may be "" in the default BYO case.
+  name  = local.resolved_app_config_scope
 }
 
-resource "databricks_secret" "account_console_id" {
-  key          = "account-console-id"
-  string_value = var.account_console_id
-  scope        = databricks_secret_scope.sat.id
-}
-
-resource "databricks_secret" "sql_warehouse_id" {
-  key          = "sql-warehouse-id"
-  string_value = var.sqlw_id == "new" ? databricks_sql_endpoint.new[0].id : data.databricks_sql_warehouse.old[0].id
-  scope        = databricks_secret_scope.sat.id
-}
-
-resource "databricks_secret" "analysis_schema_name" {
-  key          = "analysis_schema_name"
+# App config secret — analysis_schema_name for the BrickHound App valueFrom
+# binding (BRICKHOUND_SCHEMA env var).  This is the only secret the app still
+# needs; WAREHOUSE_ID now resolves from the sql_warehouse resource directly.
+#
+# Skipped when the user pre-populated this key in their own scope
+# (scope_provided_keys contains "analysis_schema_name") — SAT must not write
+# to a scope it doesn't own, and the app binding is redirected to that scope
+# by brickhound_app.tf.
+resource "databricks_secret" "app_analysis_schema" {
+  count        = contains(var.scope_provided_keys, "analysis_schema_name") ? 0 : 1
+  key          = local.secret_keys["analysis_schema_name"]
   string_value = var.analysis_schema_name
-  scope        = databricks_secret_scope.sat.id
-}
-
-resource "databricks_secret" "proxies" {
-  key          = "proxies"
-  string_value = jsonencode(var.proxies)
-  scope        = databricks_secret_scope.sat.id
+  scope = (
+    local.create_app_scope
+    ? databricks_secret_scope.sat_app_config[0].id
+    : local.scope_ref
+  )
 }

--- a/terraform/common/variables.tf
+++ b/terraform/common/variables.tf
@@ -111,3 +111,51 @@ variable "sql_warehouse_auto_stop_mins" {
   description = "Time in minutes until an idle SQL warehouse terminates all clusters and stops. This field is optional. The default is 120, set to 0 to disable the auto stop."
   default     = 120
 }
+
+variable "manage_secrets" {
+  type        = bool
+  description = "When true (default), SAT creates the secret scope and writes the client_secret. Set to false to bring a pre-existing scope — SAT will only validate that the required secret key is readable."
+  default     = true
+}
+
+variable "secret_key_names" {
+  type        = map(string)
+  description = "Override map from logical key name to physical secret key name (e.g. { client_secret = \"my-sp-secret\" }). Unspecified keys use SAT defaults."
+  default     = {}
+}
+
+variable "app_config_scope_name" {
+  type        = string
+  description = "Secret scope for BrickHound app valueFrom bindings (analysis_schema_name, sql-warehouse-id). Defaults to secret_scope_name. Only relevant when manage_secrets=false and you need to keep your credential scope pristine."
+  default     = ""
+}
+
+variable "client_id" {
+  type        = string
+  description = "Service Principal Application (client) ID"
+  default     = ""
+}
+
+variable "tenant_id" {
+  type        = string
+  description = "Azure Tenant ID (Azure only)"
+  default     = ""
+}
+
+variable "subscription_id" {
+  type        = string
+  description = "Azure Subscription ID (Azure only)"
+  default     = ""
+}
+
+variable "use_sp_auth" {
+  type        = bool
+  description = "Use Service Principal OAuth authentication (AWS and GCP only)"
+  default     = true
+}
+
+variable "scope_provided_keys" {
+  type        = list(string)
+  description = "Logical key names that are pre-populated in the user's existing scope and must not be written by SAT. Mirrors the scope_contains checkbox in the DABS installer. Supported values: client_secret, account_id, client_id, tenant_id, subscription_id, proxies, analysis_schema_name."
+  default     = []
+}

--- a/terraform/gcp/TERRAFORM_GCP.md
+++ b/terraform/gcp/TERRAFORM_GCP.md
@@ -155,7 +155,23 @@ Supplemental Documentation:
 
 Additional Considerations:
 
-Your jobs may fail if there was a pre-existing secret scope named `sat_scope` when you run `terraform apply`. To remedy this, you will need to change the name of your secret scope in `secrets.tf`, re-run terraform apply, and then navigate to `Workspace -> Applications -> SAT-TF /notebooks/Utils/initialize` and change the secret scope name in  6 places (3 times in CMD 4 and 3 times in CMD 5). You then can re-run your failed jobs.
+**Using a custom or pre-existing secret scope:**
+
+Set `secret_scope_name` in `terraform.tfvars` to use a different scope name:
+
+```hcl
+secret_scope_name = "sat_scope_prod"
+```
+
+To bring a pre-existing scope, set `manage_secrets = false`:
+
+```hcl
+manage_secrets = false
+secret_scope_name = "my-existing-scope"
+# secret_key_names = { client_secret = "my-sp-client-secret" }
+```
+
+See the [Secret Scope Reference](https://databricks-industry-solutions.github.io/security-analysis-tool/docs/installation/secret-scope) for the full list of required keys and ACL requirements.
 
 If `terraform apply` fails with `An app with the same name already exists` for `sat-permissions-exp` (typically because BrickHound was previously deployed via the DABS installer or a prior Terraform state was lost), import the existing app into Terraform state and re-apply:
 

--- a/terraform/gcp/provider.tf
+++ b/terraform/gcp/provider.tf
@@ -23,6 +23,12 @@ module "common" {
   proxies                         = var.proxies
   run_on_serverless               = var.run_on_serverless
   secret_scope_name               = var.secret_scope_name
+  manage_secrets                  = var.manage_secrets
+  secret_key_names                = var.secret_key_names
+  app_config_scope_name           = var.app_config_scope_name
+  scope_provided_keys             = var.scope_provided_keys
+  client_id                       = var.client_id
+  use_sp_auth                     = var.use_sp_auth
   secrets_scanner_cron_expression = var.secrets_scanner_cron_expression
   driver_cron_expression          = var.driver_cron_expression
   job_compute_num_workers         = var.job_compute_num_workers

--- a/terraform/gcp/secrets.tf
+++ b/terraform/gcp/secrets.tf
@@ -1,19 +1,12 @@
 ### GCP Specific Secrets
-
-resource "databricks_secret" "use_sp_auth" {
-  key          = "use-sp-auth"
-  string_value = var.use_sp_auth
-  scope        = module.common.secret_scope_id
-}
-
-resource "databricks_secret" "client_id" {
-  key          = "client-id"
-  string_value = var.client_id
-  scope        = module.common.secret_scope_id
-}
+#
+# Only the credential secret is stored in the scope. All other values
+# (client_id, use_sp_auth, etc.) are passed as direct job base_parameters
+# via locals.sat_base_parameters and never need to be secrets.
 
 resource "databricks_secret" "client_secret" {
-  key          = "client-secret"
+  count        = var.manage_secrets ? 1 : 0
+  key          = module.common.secret_keys_resolved["client_secret"]
   string_value = var.client_secret
   scope        = module.common.secret_scope_id
 }

--- a/terraform/gcp/template.tfvars
+++ b/terraform/gcp/template.tfvars
@@ -42,3 +42,24 @@ run_on_serverless = false # [Only monitor current workspace]
 # Customize to use a different scope name (useful for multiple SAT instances or naming conventions)
 # Example: "sat_scope_prod" or "sat_scope_scan1"
 # secret_scope_name = "sat_scope"
+
+# Bring Your Own Secret Scope (Optional)
+# Set manage_secrets = false if you have a pre-existing secret scope that SAT should read from.
+# SAT will only write the client_secret key (the only true credential).
+# manage_secrets = true
+
+# Secret Key Name Overrides (Optional)
+# Map logical names to physical names for keys in your existing scope.
+# Example: { client_secret = "my-sp-client-secret" }
+# secret_key_names = {}
+
+# App Config Scope (Optional — only relevant when manage_secrets = false)
+# Scope for BrickHound app valueFrom bindings (analysis_schema_name, sql-warehouse-id).
+# app_config_scope_name = ""
+# Pre-existing scope keys (Optional — only relevant when manage_secrets = false)
+# List the logical names of values that are already in your scope.
+# SAT will not write them and the BrickHound app binding will point at your scope.
+# Supported: client_secret, account_id, client_id, tenant_id, subscription_id,
+#            proxies, analysis_schema_name
+# Example: scope_provided_keys = ["client_secret", "analysis_schema_name"]
+# scope_provided_keys = []

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -29,6 +29,24 @@ variable "secret_scope_name" {
   default     = "sat_scope"
 }
 
+variable "manage_secrets" {
+  type        = bool
+  description = "When true (default), SAT creates the secret scope and writes the client_secret. Set to false to bring a pre-existing scope."
+  default     = true
+}
+
+variable "secret_key_names" {
+  type        = map(string)
+  description = "Override map from logical key name to physical secret key name."
+  default     = {}
+}
+
+variable "app_config_scope_name" {
+  type        = string
+  description = "Secret scope for BrickHound app valueFrom bindings. Defaults to secret_scope_name."
+  default     = ""
+}
+
 variable "analysis_schema_name" {
   type        = string
   description = "Name of the schema to be used for analysis"
@@ -103,4 +121,9 @@ variable "job_schedule_timezone_id" {
     condition     = can(regex("^([A-Za-z]+(/[A-Za-z0-9_+\\-]+)+|UTC)$", var.job_schedule_timezone_id))
     error_message = "Must be a valid IANA time zone ID (e.g. America/New_York, Etc/UTC) or UTC."
   }
+}
+variable "scope_provided_keys" {
+  type        = list(string)
+  description = "Logical key names pre-populated in the user's existing scope. Mirrors the DABS scope_contains checkbox. SAT will not write these keys and the app binding uses the user's scope directly."
+  default     = []
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our versioning guidelines: https://github.com/databricks-industry-solutions/security-analysis-tool/blob/main/VERSIONING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

Only client_secret (and workspace PATs) must live in a secret scope. All other values — account_id, client_id, sql_warehouse_id, etc. — are now passed as direct job base_parameters and resolved at runtime via a 4-step chain: param > scope fallback > safe default > hard fail. This keeps 0.8.x installs (values still in scope) working unchanged.

New config surface (DABS + Terraform, identical semantics):
- secret_scope_name  – scope to read from (default: sat_scope)
- manage_secrets     – false = BYO pre-populated scope; SAT writes nothing
- secret_key_names   – override map logical->physical key names
- app_config_scope_name – separate scope for BrickHound app valueFrom bindings

Notebooks:
- common.py: add DEFAULT_SECRET_KEYS, resolve_sat_value(), read_sat_secret()
- initialize.py: replace hardcoded SECRETS_SCOPE + 11 literal secret reads with widgets + resolver; expose secret_scope/secret_keys in json_ for all child notebooks
- brickhound 00_config/05/06/07: use json_[analysis_schema_name] and read_sat_secret() instead of direct dbutils.secrets.get literals
- permission_analysis_data_collection.py: use json_ values + scope fallback
- pre_run_config_check.py: rewrite to validate only client_secret in scope; all other values already verified via json_ from initialize.py
- sat_diagnosis_*: replace hardcoded key literals; remove plaintext credential dump loops (print(secretvalue) for every key in scope)

DABS:
- config.py: 4 new prompts; generate_secrets() writes only client-secret; new validate_secrets() for manage_secrets=false
- main.py: pass all 10 config values into tmp_config.json for templates
- 4 job templates: add base_parameters to every notebook_task
- brickhound_job.yml.tmpl: app resources use {{.app_config_scope}}

Terraform:
- common/locals.tf (new): secret_keys, scope_ref, sat_base_parameters, app config scope logic
- secrets.tf: delete dead/non-secret resources (user, pass, user-email-for-alerts, account-console-id, sql-warehouse-id, analysis_schema_name, proxies, use-sp-auth, client-id); keep only client_secret per cloud; add manage_secrets count guard and app config scope resources
- all 7 notebook_task blocks: base_parameters = merge(sat_base_parameters)
- brickhound_app.tf: scope/key use locals
- variables.tf (all 4): add manage_secrets, secret_key_names, app_config_scope_name
- template.tfvars (all 3): document new variables

Docs:
- docs/installation/secret-scope.mdx (new): key reference table, BYO scope instructions, resolution order, ACL requirements, Azure KV note
- sidebars.ts: register new page
- terraform/{aws,azure,gcp}.mdx + TERRAFORM_*.md: replace stale 'edit initialize in 6 places' instructions with manage_secrets examples
- troubleshooting.mdx: fix dead sat_tokens key name; add BYO ACL entries

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (non-code changes like README or docs)

## How Has This Been Tested?

I tested the standard install on my own workspace and account

## Checklist
- [X] I have reviewed the [CONTRIBUTING](https://github.com/databricks-industry-solutions/security-analysis-tool/blob/main/CONTRIBUTING.md) and [VERSIONING](https://github.com/databricks-industry-solutions/security-analysis-tool/blob/main/VERSIONING.md) documentation.
- [X] My code follows the code style of this project.
- [X] I have verified, added or updated the tests to cover my changes (if applicable).
- [X] I have verified that my changes do not introduce any breaking changes on all the supported clouds (AWS, Azure, GCP).
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation (if applicable).

## Screenshots (If Applicable)

### `sat-permission-exp` after

Brought my own secret scope and removed secret that was not needed

<img width="845" height="862" alt="image" src="https://github.com/user-attachments/assets/2dfcdc66-9b85-4946-b31b-566e86759c4a" />


## Additional Notes
<!--
Add any other relevant info here (e.g., deployment changes, new tests, breaking API changes, external dependencies).
-->