### PR TITLE
feat(permissions-analysis): workspace identity changes detection + report robustness fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -643,7 +643,8 @@ BrickHound provides graph-based permissions analysis within SAT, complementing S
 - `analysis_schema_name` → Unity Catalog schema (catalog.schema format)
 
 **Storage**: Same Unity Catalog schema as SAT
-- Tables: `brickhound_vertices`, `brickhound_edges`, `brickhound_collection_metadata`
+- Graph tables: `brickhound_vertices`, `brickhound_edges`, `brickhound_collection_metadata`
+- Account-level detection tables (notebooks 05–08, audit-log/SCIM based): `brickhound_shared_to_account`, `brickhound_privileged_non_idp`, `brickhound_denylist_candidates`, `brickhound_workspace_identity_changes` (each run_id-stamped)
 - Namespaced with `brickhound_` prefix to avoid conflicts
 
 **Job**: Separate weekly job (Sunday 2 AM)

--- a/app/brickhound/app.py
+++ b/app/brickhound/app.py
@@ -96,6 +96,7 @@ METADATA_TABLE = f"`{CATALOG}`.`{SCHEMA}`.brickhound_collection_metadata"
 SHARED_TO_ACCOUNT_TABLE = f"`{CATALOG}`.`{SCHEMA}`.brickhound_shared_to_account"
 PRIVILEGED_NON_IDP_TABLE = f"`{CATALOG}`.`{SCHEMA}`.brickhound_privileged_non_idp"
 DENYLIST_CANDIDATES_TABLE = f"`{CATALOG}`.`{SCHEMA}`.brickhound_denylist_candidates"
+WORKSPACE_IDENTITY_CHANGES_TABLE = f"`{CATALOG}`.`{SCHEMA}`.brickhound_workspace_identity_changes"
 
 # Max rows any single report renders. Report queries fetch REPORT_ROW_CAP + 1 so
 # the endpoint can detect truncation; the extra row is trimmed before display.
@@ -1737,6 +1738,10 @@ def get_main_html():
                             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M12 8v4"/><path d="M12 16h.01"/></svg>
                             Privileged Non-IdP
                         </div>
+                        <div class="nav-item" data-page="workspaceidentity">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 11l-3 3-1.5-1.5"/></svg>
+                            Workspace Identity Changes
+                        </div>
                     </div>
                 </div>
                 
@@ -2225,6 +2230,15 @@ def get_main_html():
                     <div id="entra-rule-builder"></div>
                 </div>
             </div>
+
+            <!-- Workspace & Identity Changes Report Page -->
+            <div class="page" id="page-workspaceidentity">
+                <div class="page-header">
+                    <h1 class="page-title">Workspace &amp; Identity Changes</h1>
+                    <p class="page-desc">Identities created or changed outside the Automatic Identity Management sync (human, not the IdP), and non-IdP-managed identities assigned to workspaces. Flagged rows need review; assignments of IdP-managed identities and AIM-sync events are recorded as the governed baseline. Detected by the SAT workspace &amp; identity changes job.</p>
+                </div>
+                <div id="workspaceidentity-results"></div>
+            </div>
         </main>
     </div>
 
@@ -2294,6 +2308,7 @@ def get_main_html():
             else if (page === 'secretscopes') loadSecretScopeAccess();
             else if (page === 'sharedtoaccount') loadSharedToAccount();
             else if (page === 'privilegednonidp') loadPrivilegedNonIdp();
+            else if (page === 'workspaceidentity') loadWorkspaceIdentityChanges();
             else if (page === 'denylistbuilder') loadDenylistBuilder();
             else if (page === 'impersonation') {
                 // Load principals for both dropdowns
@@ -4067,6 +4082,140 @@ def get_main_html():
                 + ` border-radius: 10px; padding: 12px 16px; margin-bottom: 16px; font-size: 0.9em; color: var(--text-primary);">`
                 + `⚠️ Showing the first ${cap.toLocaleString()} rows — this detection run has more findings than that.`
                 + ` Query the findings table directly for the complete set.</div>`;
+        }
+
+        async function loadWorkspaceIdentityChanges() {
+            const container = document.getElementById('workspaceidentity-results');
+            container.innerHTML = '<div class="loading">Loading workspace &amp; identity changes...</div>';
+
+            try {
+                const res = await fetch('/api/report/workspace-identity-changes');
+                const result = await res.json();
+
+                if (result.error) {
+                    showEmpty('workspaceidentity-results', result.error);
+                    return;
+                }
+
+                const data = result.data || [];
+                const summary = result.summary || {};
+
+                if (data.length === 0) {
+                    showEmpty('workspaceidentity-results', 'No workspace/identity changes were found in the latest detection run.');
+                    return;
+                }
+
+                const detTs = result.detection_timestamp
+                    ? escapeHtml(String(result.detection_timestamp).replace('T', ' ').slice(0, 19)) + ' UTC'
+                    : 'Unknown';
+                const metastores = (result.metastores || []).map(m => ({name: m, reason: 'ok'}));
+
+                const catLabels = {
+                    identity_created: 'Identity created',
+                    group_membership_add: 'Group membership added',
+                    admin_grant: 'Account admin granted',
+                    workspace_assignment_add: 'Workspace assignment',
+                    workspace_assignment_remove: 'Workspace assignment removed',
+                    account_workspace_access: 'Workspace access (account admin)'
+                };
+                const catEmoji = {
+                    identity_created: '🆕', group_membership_add: '👥', admin_grant: '🛡️',
+                    workspace_assignment_add: '🏢', workspace_assignment_remove: '🚪',
+                    account_workspace_access: '🏛️'
+                };
+
+                const renderRow = (item, isLast) => {
+                    const who = formatPrincipalName(item.principal_name, item.principal_email || item.application_id, null, item.principal_id);
+                    const nameHtml = item.console_url
+                        ? `<a href="${escapeHtml(item.console_url)}" target="_blank" rel="noopener noreferrer" style="color: var(--accent); text-decoration: none;">${who}</a>`
+                        : who;
+                    const catLabel = catLabels[item.change_category] || item.change_category;
+                    const idpBadge = item.principal_type === 'Unknown'
+                        ? ' · <span style="color: var(--text-muted);">Unknown principal</span>'
+                        : (item.is_idp_managed
+                            ? ' · <span style="color: #10b981;">IdP-managed</span>'
+                            : ' · <span style="color: #ef4444;">⚠ Non-IdP</span>');
+                    const aimBadge = item.is_aim_sync
+                        ? ' · <span style="color: var(--text-muted);">AIM sync</span>'
+                        : ' · <span style="color: var(--warning);">👤 Human</span>';
+                    const viaLabel = item.changed_via === 'workspace_admin' ? 'Workspace admin' : 'Account admin';
+                    const ws = (item.workspace_name || item.workspace_id)
+                        ? ` · 🏢 ${escapeHtml(item.workspace_name || item.workspace_id)}` : '';
+                    const grp = item.related_group ? ` · → ${escapeHtml(item.related_group)}` : '';
+                    const perm = item.permission ? ` · ${escapeHtml(item.permission)}` : '';
+                    const when = item.event_time ? escapeHtml(String(item.event_time).replace('T', ' ').slice(0, 19)) : '';
+                    const rem = item.auto_remediated ? ' · <span style="color: #10b981;">✓ Remediated</span>' : '';
+                    const reason = item.flagged && item.flag_reason
+                        ? `<div style="font-size: 0.8em; color: #ef4444; margin-top: 4px;">⚠ ${escapeHtml(item.flag_reason.replace(/_/g, ' '))}</div>` : '';
+                    return `
+                        <div style="display: flex; align-items: flex-start; gap: 12px; padding: 12px 24px; border-bottom: ${isLast ? 'none' : '1px solid var(--border)'};">
+                            <span style="font-size: 16px;">${catEmoji[item.change_category] || '•'}</span>
+                            <div style="flex: 1; min-width: 0;">
+                                <div style="font-weight: 500; word-break: break-word;">${nameHtml}</div>
+                                <div style="font-size: 0.82em; color: var(--text-secondary); margin-top: 3px;">
+                                    ${escapeHtml(catLabel)}${perm}${grp}${idpBadge}${aimBadge}${rem}
+                                </div>
+                                <div style="font-size: 0.78em; color: var(--text-muted); margin-top: 3px;">
+                                    ${escapeHtml(viaLabel)}${ws} · by ${escapeHtml(item.actor_email || 'unknown')}${when ? ` · ${when} UTC` : ''}
+                                </div>
+                                ${reason}
+                            </div>
+                        </div>`;
+                };
+
+                const flaggedItems = data.filter(d => d.flagged);
+                const recordedItems = data.filter(d => !d.flagged);
+
+                let html = `
+                    ${renderTruncationBanner(result)}
+                    ${renderCoverageBlock({
+                        dateTs: detTs,
+                        scopeLabel: 'Metastores',
+                        scopeIcon: '🗄️',
+                        scanned: metastores,
+                        failed: [],
+                        inReport: result.workspaces || [],
+                        note: 'Detection is account-wide over the audit log (system.access.audit) of the metastore above; the entities in this report are the workspaces where changes were found.'
+                    })}
+                    <div style="background: var(--bg-input); border-radius: 12px; padding: 16px 20px; margin-bottom: 16px;">
+                        <div style="font-weight: 600; margin-bottom: 12px; color: var(--text-secondary);">Workspace &amp; Identity Changes</div>
+                        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(100px, 1fr)); gap: 12px; text-align: center;">
+                            <div><div style="font-size: 1.8em; font-weight: 700; color: var(--accent);">${summary.total || 0}</div><div style="font-size: 0.75em; color: var(--text-muted); text-transform: uppercase;">Total</div></div>
+                            <div><div style="font-size: 1.8em; font-weight: 700; color: #ef4444;">${summary.flagged || 0}</div><div style="font-size: 0.75em; color: var(--text-muted); text-transform: uppercase;">Flagged</div></div>
+                            <div><div style="font-size: 1.8em; font-weight: 700; color: #10b981;">${summary.remediated || 0}</div><div style="font-size: 0.75em; color: var(--text-muted); text-transform: uppercase;">Remediated</div></div>
+                            <div><div style="font-size: 1.8em; font-weight: 700; color: var(--text-secondary);">${summary.aim_sync || 0}</div><div style="font-size: 0.75em; color: var(--text-muted); text-transform: uppercase;">AIM Sync</div></div>
+                        </div>
+                    </div>`;
+
+                if (flaggedItems.length) {
+                    html += `
+                        <div class="results-container" style="margin-bottom: 16px;">
+                            <div class="results-header">
+                                <span class="results-title" style="color: #ef4444;">⚠ Flagged — needs review</span>
+                                <span class="results-count">${flaggedItems.length}</span>
+                            </div>
+                            <div class="results-body" style="padding: 0;">
+                                ${flaggedItems.map((it, i) => renderRow(it, i === flaggedItems.length - 1)).join('')}
+                            </div>
+                        </div>`;
+                }
+                if (recordedItems.length) {
+                    html += `
+                        <div class="results-container">
+                            <div class="results-header">
+                                <span class="results-title">Recorded — governed baseline</span>
+                                <span class="results-count">${recordedItems.length}</span>
+                            </div>
+                            <div class="results-body" style="padding: 0;">
+                                ${recordedItems.map((it, i) => renderRow(it, i === recordedItems.length - 1)).join('')}
+                            </div>
+                        </div>`;
+                }
+
+                container.innerHTML = html;
+            } catch (e) {
+                showEmpty('workspaceidentity-results', 'Error: ' + e.message);
+            }
         }
 
         async function loadPrivilegedNonIdp() {
@@ -8232,6 +8381,105 @@ def report_privileged_non_idp():
         'workspaces_scanned': scanned,
         'workspaces_failed': failed,
         'workspaces_in_report': in_report,
+        'truncated': truncated,
+        'row_cap': REPORT_ROW_CAP,
+        'data': results,
+    })
+
+
+@app.route('/api/report/workspace-identity-changes')
+def report_workspace_identity_changes():
+    """Workspace/identity changes from the audit log.
+
+    Reads the latest snapshot from brickhound_workspace_identity_changes, populated
+    by notebooks/brickhound/08_workspace_identity_changes.py. Read-only; remediation
+    happens in the notebook/job (which holds SP credentials).
+    """
+    query = f"""
+    WITH latest AS (
+        SELECT MAX(run_id) AS run_id FROM {WORKSPACE_IDENTITY_CHANGES_TABLE}
+    )
+    SELECT
+        c.change_category,
+        c.changed_via,
+        c.action_name,
+        c.is_aim_sync,
+        c.actor_email,
+        c.source_ip,
+        c.principal_id,
+        c.principal_type,
+        c.principal_name,
+        c.principal_email,
+        c.is_idp_managed,
+        c.related_group,
+        c.permission,
+        c.workspace_id,
+        c.workspace_name,
+        c.flagged,
+        c.flag_reason,
+        c.console_url,
+        CAST(c.event_time AS STRING)          AS event_time,
+        CAST(c.detection_timestamp AS STRING) AS detection_timestamp,
+        c.auto_remediated
+    FROM {WORKSPACE_IDENTITY_CHANGES_TABLE} c
+    JOIN latest l ON c.run_id = l.run_id
+    ORDER BY c.flagged DESC, c.event_time DESC
+    LIMIT {REPORT_ROW_CAP + 1}
+    """
+
+    try:
+        results = exec_query_df(query)
+    except NoAccessError:
+        # No UC read grant on the findings table — let the access banner render.
+        raise
+    except Exception as e:
+        logger.warning("workspace-identity-changes report query failed: %s", e)
+        return jsonify({
+            'error': (
+                'No workspace/identity-change data available yet. Run the '
+                '"SAT Permissions Analysis - Workspace & Identity Changes" job (or the '
+                'notebooks/brickhound/08_workspace_identity_changes.py notebook) to populate it.'
+            )
+        })
+
+    truncated = len(results) > REPORT_ROW_CAP
+    if truncated:
+        results = results[:REPORT_ROW_CAP]
+
+    # Statement Execution returns booleans as strings; normalize for the JS layer.
+    for r in results:
+        r['flagged'] = _truthy(r.get('flagged'))
+        r['is_idp_managed'] = _truthy(r.get('is_idp_managed'))
+        r['is_aim_sync'] = _truthy(r.get('is_aim_sync'))
+        r['auto_remediated'] = _truthy(r.get('auto_remediated'))
+
+    flagged = sum(1 for r in results if r['flagged'])
+    remediated = sum(1 for r in results if r['auto_remediated'])
+    aim_sync = sum(1 for r in results if r['is_aim_sync'])
+
+    detection_timestamp = results[0]['detection_timestamp'] if results else None
+    metastores = []
+    try:
+        rows = exec_query_df("SELECT current_metastore() AS m")
+        if rows and rows[0].get('m'):
+            metastores = [rows[0]['m']]
+    except Exception:
+        metastores = []
+
+    # Workspaces named in this report (assignment findings carry a workspace_name).
+    workspaces = sorted({r['workspace_name'] for r in results if r.get('workspace_name')})
+
+    return jsonify({
+        'success': True,
+        'summary': {
+            'total': len(results),
+            'flagged': flagged,
+            'remediated': remediated,
+            'aim_sync': aim_sync,
+        },
+        'metastores': metastores,
+        'detection_timestamp': detection_timestamp,
+        'workspaces': workspaces,
         'truncated': truncated,
         'row_cap': REPORT_ROW_CAP,
         'data': results,

--- a/app/brickhound/app.py
+++ b/app/brickhound/app.py
@@ -4276,8 +4276,11 @@ def get_main_html():
                     html += `
                         <div class="results-container rem-group">
                             <div class="results-header">
-                                <span class="results-title">Recorded — governed baseline</span>
+                                <span class="results-title">Recorded — review discretionary</span>
                                 <span class="results-count">${recordedItems.length}</span>
+                            </div>
+                            <div style="padding: 8px 24px; font-size: 0.78em; color: var(--text-muted); border-bottom: 1px solid var(--border);">
+                                Non-flagged events kept for context — the governed baseline (assignments of IdP-managed identities, AIM-sync provisioning) and removal events, including assignment removals performed by this tool's own remediation. Review at your discretion.
                             </div>
                             <div class="results-body" style="padding: 0;">
                                 ${recordedItems.map((it, i) => renderRow(it, i === recordedItems.length - 1)).join('')}

--- a/app/brickhound/app.py
+++ b/app/brickhound/app.py
@@ -4084,12 +4084,53 @@ def get_main_html():
                 + ` Query the findings table directly for the complete set.</div>`;
         }
 
-        async function loadWorkspaceIdentityChanges() {
+        // Controls bar for the account-level report tabs: a per-run selector
+        // (server-side re-fetch) + a remediated filter (client-side row toggle).
+        function renderReportControls(cfg) {
+            const runs = cfg.runs || [];
+            const sel = cfg.selectedRunId;
+            let runOpts = runs.map(r => {
+                const ts = r.detection_timestamp
+                    ? escapeHtml(String(r.detection_timestamp).replace('T', ' ').slice(0, 19)) + ' UTC'
+                    : escapeHtml(r.run_id);
+                return `<option value="${escapeHtml(r.run_id)}"${r.run_id === sel ? ' selected' : ''}>${ts}</option>`;
+            }).join('');
+            if (!runs.length) runOpts = '<option value="">(latest)</option>';
+            const runSel = `<label style="font-size: 0.8em; color: var(--text-secondary);">Detection run</label>`
+                + `<select onchange="${cfg.runOnChange}" style="padding: 6px 10px; background: var(--bg-input); border: 1px solid var(--border); border-radius: 6px; color: var(--text-primary); font-size: 0.9em; cursor: pointer; max-width: 340px;">${runOpts}</select>`;
+            let filterSel = '';
+            if (cfg.filterScopeId) {
+                filterSel = `<label style="font-size: 0.8em; color: var(--text-secondary); margin-left: 16px;">Show</label>`
+                    + `<select onchange="applyRemFilter('${cfg.filterScopeId}', this.value)" style="padding: 6px 10px; background: var(--bg-input); border: 1px solid var(--border); border-radius: 6px; color: var(--text-primary); font-size: 0.9em; cursor: pointer;">`
+                    + `<option value="all">All</option><option value="true">Remediated</option><option value="false">Not remediated</option></select>`;
+            }
+            return `<div style="display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin-bottom: 16px;">${runSel}${filterSel}</div>`;
+        }
+
+        // Client-side remediated filter: toggle leaf rows ([data-rem]) and hide any
+        // grouping wrapper (.rem-group) left with no visible rows.
+        function applyRemFilter(scopeId, val) {
+            const scope = document.getElementById(scopeId);
+            if (!scope) return;
+            scope.querySelectorAll('[data-rem]').forEach(el => {
+                const show = (val === 'all')
+                    || (val === 'true' && el.dataset.rem === 'true')
+                    || (val === 'false' && el.dataset.rem === 'false');
+                el.style.display = show ? '' : 'none';
+            });
+            scope.querySelectorAll('.rem-group').forEach(g => {
+                const anyVisible = Array.from(g.querySelectorAll('[data-rem]')).some(el => el.style.display !== 'none');
+                g.style.display = anyVisible ? '' : 'none';
+            });
+        }
+
+        async function loadWorkspaceIdentityChanges(runId) {
             const container = document.getElementById('workspaceidentity-results');
             container.innerHTML = '<div class="loading">Loading workspace identity changes...</div>';
 
             try {
-                const res = await fetch('/api/report/workspace-identity-changes');
+                const url = '/api/report/workspace-identity-changes' + (runId ? ('?run_id=' + encodeURIComponent(runId)) : '');
+                const res = await fetch(url);
                 const result = await res.json();
 
                 if (result.error) {
@@ -4154,11 +4195,19 @@ def get_main_html():
                     const grp = item.related_group ? ` · → ${escapeHtml(item.related_group)}` : '';
                     const perm = item.permission ? ` · ${escapeHtml(item.permission)}` : '';
                     const when = item.event_time ? escapeHtml(String(item.event_time).replace('T', ' ').slice(0, 19)) : '';
-                    const rem = item.auto_remediated ? ' · <span style="color: #10b981;">✓ Remediated</span>' : '';
+                    let rem = '';
+                    if (item.remediation_action) {
+                        const acts = String(item.remediation_action).split(',').map(a =>
+                            a === 'assignment_removed' ? '✓ Assignment removed'
+                            : a === 'identity_disabled' ? '✓ Identity disabled' : a);
+                        rem = ' · <span style="color: #10b981;">' + escapeHtml(acts.join(', ')) + '</span>';
+                    } else if (item.auto_remediated) {
+                        rem = ' · <span style="color: #10b981;">✓ Remediated</span>';
+                    }
                     const reason = item.flagged && item.flag_reason
                         ? `<div style="font-size: 0.8em; color: #ef4444; margin-top: 4px;">⚠ ${escapeHtml(item.flag_reason.replace(/_/g, ' '))}</div>` : '';
                     return `
-                        <div style="display: flex; align-items: flex-start; gap: 12px; padding: 12px 24px; border-bottom: ${isLast ? 'none' : '1px solid var(--border)'};">
+                        <div data-rem="${item.auto_remediated ? 'true' : 'false'}" style="display: flex; align-items: flex-start; gap: 12px; padding: 12px 24px; border-bottom: ${isLast ? 'none' : '1px solid var(--border)'};">
                             <span style="font-size: 16px;">${catEmoji[item.change_category] || '•'}</span>
                             <div style="flex: 1; min-width: 0;">
                                 <div style="font-weight: 500; word-break: break-word;">${nameHtml}${typeChip}</div>
@@ -4178,6 +4227,7 @@ def get_main_html():
 
                 let html = `
                     ${renderTruncationBanner(result)}
+                    ${renderReportControls({runs: result.runs, selectedRunId: result.selected_run_id, runOnChange: 'loadWorkspaceIdentityChanges(this.value)', filterScopeId: 'workspaceidentity-results'})}
                     ${renderCoverageBlock({
                         dateTs: detTs,
                         scopeLabel: 'Metastores',
@@ -4199,7 +4249,7 @@ def get_main_html():
 
                 if (flaggedItems.length) {
                     html += `
-                        <div class="results-container" style="margin-bottom: 16px;">
+                        <div class="results-container rem-group" style="margin-bottom: 16px;">
                             <div class="results-header">
                                 <span class="results-title" style="color: #ef4444;">⚠ Flagged — needs review</span>
                                 <span class="results-count">${flaggedItems.length}</span>
@@ -4211,7 +4261,7 @@ def get_main_html():
                 }
                 if (recordedItems.length) {
                     html += `
-                        <div class="results-container">
+                        <div class="results-container rem-group">
                             <div class="results-header">
                                 <span class="results-title">Recorded — governed baseline</span>
                                 <span class="results-count">${recordedItems.length}</span>
@@ -4228,12 +4278,13 @@ def get_main_html():
             }
         }
 
-        async function loadPrivilegedNonIdp() {
+        async function loadPrivilegedNonIdp(runId) {
             const container = document.getElementById('privilegednonidp-results');
             container.innerHTML = '<div class="loading">Loading privileged non-IdP identities...</div>';
 
             try {
-                const res = await fetch('/api/report/privileged-non-idp');
+                const url = '/api/report/privileged-non-idp' + (runId ? ('?run_id=' + encodeURIComponent(runId)) : '');
+                const res = await fetch(url);
                 const result = await res.json();
 
                 if (result.error) {
@@ -4265,6 +4316,7 @@ def get_main_html():
 
                 let html = `
                     ${renderTruncationBanner(result)}
+                    ${renderReportControls({runs: result.runs, selectedRunId: result.selected_run_id, runOnChange: 'loadPrivilegedNonIdp(this.value)', filterScopeId: 'privilegednonidp-results'})}
                     ${renderCoverageBlock({
                         dateTs: detTs,
                         scopeLabel: 'Workspaces',
@@ -4305,7 +4357,7 @@ def get_main_html():
 
                     // Role header
                     html += `
-                        <div class="tree-type-group">
+                        <div class="tree-type-group rem-group">
                             <div style="display: flex; align-items: center; gap: 12px; padding: 14px 24px; background: var(--bg-input); border-bottom: 1px solid var(--border);">
                                 <span style="font-size: 20px;">🛡️</span>
                                 <span style="font-weight: 700; flex: 1;">${roleLabel} (${items.length})</span>
@@ -4345,7 +4397,7 @@ def get_main_html():
                                 ? `<span style="margin-left: 10px;">🏢 Workspace: ${escapeHtml(item.workspace_name || item.workspace_id)}</span>` : '';
 
                             html += `
-                                <div class="tree-resource" style="display: flex; align-items: flex-start; gap: 12px; padding: 12px 24px 12px 64px; border-bottom: ${isLast ? 'none' : '1px solid var(--border)'};">
+                                <div data-rem="${item.auto_remediated ? 'true' : 'false'}" class="tree-resource" style="display: flex; align-items: flex-start; gap: 12px; padding: 12px 24px 12px 64px; border-bottom: ${isLast ? 'none' : '1px solid var(--border)'};">
                                     <span style="color: var(--text-muted);">${isLast ? '└─' : '├─'}</span>
                                     <div style="flex: 1; min-width: 0;">
                                         <div style="font-weight: 500; word-break: break-all;">${categoryEmoji[cat]} ${nameHtml}</div>
@@ -4368,12 +4420,13 @@ def get_main_html():
         }
 
         // Load Orphaned Resources Report
-        async function loadSharedToAccount() {
+        async function loadSharedToAccount(runId) {
             const container = document.getElementById('sharedtoaccount-results');
             container.innerHTML = '<div class="loading">Loading shared-to-account-users findings...</div>';
 
             try {
-                const res = await fetch('/api/report/shared-to-account');
+                const url = '/api/report/shared-to-account' + (runId ? ('?run_id=' + encodeURIComponent(runId)) : '');
+                const res = await fetch(url);
                 const result = await res.json();
 
                 if (result.error) {
@@ -4408,6 +4461,7 @@ def get_main_html():
 
                 let html = `
                     ${renderTruncationBanner(result)}
+                    ${renderReportControls({runs: result.runs, selectedRunId: result.selected_run_id, runOnChange: 'loadSharedToAccount(this.value)', filterScopeId: 'sharedtoaccount-results'})}
                     ${renderCoverageBlock({
                         dateTs: detTs,
                         scopeLabel: 'Metastores',
@@ -4456,7 +4510,7 @@ def get_main_html():
                     const label = typeLabels[type] || type;
 
                     html += `
-                        <div class="tree-type-group">
+                        <div class="tree-type-group rem-group">
                             <div class="tree-type-header" onclick="toggleTreeSection('${typeId}')" style="display: flex; align-items: center; gap: 12px; padding: 16px 24px; cursor: pointer; background: var(--bg-input); border-bottom: 1px solid var(--border);">
                                 <span class="tree-toggle" id="${typeId}-toggle" style="color: var(--text-muted); font-size: 12px;">▶</span>
                                 <span style="font-size: 20px;">${typeEmoji[type] || '📄'}</span>
@@ -4488,7 +4542,7 @@ def get_main_html():
                             ? `<span style="margin-left: 10px;">👥 Shared to: ${escapeHtml(item.group_name)}</span>` : '';
 
                         html += `
-                            <div class="tree-resource" style="display: flex; align-items: flex-start; gap: 12px; padding: 12px 24px 12px 56px; border-bottom: ${isLast ? 'none' : '1px solid var(--border)'};">
+                            <div data-rem="${item.auto_remediated ? 'true' : 'false'}" class="tree-resource" style="display: flex; align-items: flex-start; gap: 12px; padding: 12px 24px 12px 56px; border-bottom: ${isLast ? 'none' : '1px solid var(--border)'};">
                                 <span style="color: var(--text-muted);">${isLast ? '└─' : '├─'}</span>
                                 <div style="flex: 1; min-width: 0;">
                                     <div style="font-weight: 500; word-break: break-all;">${nameHtml}</div>
@@ -8188,21 +8242,42 @@ def report_orphaned_resources():
     })
 
 
+def _resolve_report_run(table):
+    """Resolve which detection run an account-level report should show.
+
+    Reads an optional ?run_id= (validated to a safe charset); defaults to the
+    latest. Returns (latest_cte, params, runs, selected_run_id) where latest_cte
+    is the body of the `WITH latest AS (...)` clause, and `runs` is the recent
+    distinct-run list that drives the per-tab run selector. NoAccessError from the
+    runs query propagates so the access banner renders.
+    """
+    sel = _validate_run_id(request.args.get('run_id'))
+    runs = exec_query_df(
+        f"SELECT DISTINCT run_id, CAST(detection_timestamp AS STRING) AS detection_timestamp "
+        f"FROM {table} ORDER BY run_id DESC LIMIT 20"
+    )
+    if sel:
+        return "SELECT :sel_run_id AS run_id", {"sel_run_id": sel}, runs, sel
+    selected = runs[0]['run_id'] if runs else None
+    return f"SELECT MAX(run_id) AS run_id FROM {table}", None, runs, selected
+
+
 @app.route('/api/report/shared-to-account')
 def report_shared_to_account():
     """Resources shared with the built-in 'account users' group.
 
-    Reads the latest snapshot from brickhound_shared_to_account, which is
-    populated by the SAT shared-to-account-users detection notebook/job
+    Reads a snapshot from brickhound_shared_to_account (latest run by default, or
+    ?run_id=), populated by the SAT shared-to-account-users detection notebook/job
     (notebooks/brickhound/05_share_to_account.py). This endpoint is read-only;
     remediation happens only in the notebook/job which holds SP credentials.
     """
     # This report has its own run_id (per detection run), independent of the
     # graph collection run_id. Query runs as the calling user (OBO), so Unity
     # Catalog enforces their grants on the findings table.
+    latest_cte, run_params, runs, selected_run_id = _resolve_report_run(SHARED_TO_ACCOUNT_TABLE)
     query = f"""
     WITH latest AS (
-        SELECT MAX(run_id) AS run_id FROM {SHARED_TO_ACCOUNT_TABLE}
+        {latest_cte}
     )
     SELECT
         s.resource_type,
@@ -8224,7 +8299,7 @@ def report_shared_to_account():
     """
 
     try:
-        results = exec_query_df(query)
+        results = exec_query_df(query, params=run_params)
     except NoAccessError:
         # No UC read grant on the findings table — let the access banner render.
         raise
@@ -8276,6 +8351,8 @@ def report_shared_to_account():
         'metastores': metastores,
         'detection_timestamp': detection_timestamp,
         'workspaces': workspaces,
+        'runs': runs,
+        'selected_run_id': selected_run_id,
         'truncated': truncated,
         'row_cap': REPORT_ROW_CAP,
         'data': results,
@@ -8290,9 +8367,10 @@ def report_privileged_non_idp():
     notebooks/brickhound/06_privileged_non_idp_identities.py. Read-only;
     remediation happens in the notebook/job (which holds SP credentials).
     """
+    latest_cte, run_params, runs, selected_run_id = _resolve_report_run(PRIVILEGED_NON_IDP_TABLE)
     query = f"""
     WITH latest AS (
-        SELECT MAX(run_id) AS run_id FROM {PRIVILEGED_NON_IDP_TABLE}
+        {latest_cte}
     )
     SELECT
         p.finding_type,
@@ -8315,7 +8393,7 @@ def report_privileged_non_idp():
     """
 
     try:
-        results = exec_query_df(query)
+        results = exec_query_df(query, params=run_params)
     except NoAccessError:
         # No UC read grant on the findings table — let the access banner render.
         raise
@@ -8353,13 +8431,13 @@ def report_privileged_non_idp():
     # inline result limit, which the endpoint would surface as a false "no data".
     cov_rows = exec_query_df(f"""
         WITH latest AS (
-            SELECT MAX(run_id) AS run_id FROM {PRIVILEGED_NON_IDP_TABLE}
+            {latest_cte}
         )
         SELECT p.workspaces_scanned, p.workspaces_failed
         FROM {PRIVILEGED_NON_IDP_TABLE} p
         JOIN latest l ON p.run_id = l.run_id
         LIMIT 1
-    """)
+    """, params=run_params)
 
     def _cov(col):
         if cov_rows and cov_rows[0].get(col):
@@ -8391,6 +8469,8 @@ def report_privileged_non_idp():
         'workspaces_scanned': scanned,
         'workspaces_failed': failed,
         'workspaces_in_report': in_report,
+        'runs': runs,
+        'selected_run_id': selected_run_id,
         'truncated': truncated,
         'row_cap': REPORT_ROW_CAP,
         'data': results,
@@ -8405,9 +8485,10 @@ def report_workspace_identity_changes():
     by notebooks/brickhound/08_workspace_identity_changes.py. Read-only; remediation
     happens in the notebook/job (which holds SP credentials).
     """
+    latest_cte, run_params, runs, selected_run_id = _resolve_report_run(WORKSPACE_IDENTITY_CHANGES_TABLE)
     query = f"""
     WITH latest AS (
-        SELECT MAX(run_id) AS run_id FROM {WORKSPACE_IDENTITY_CHANGES_TABLE}
+        {latest_cte}
     )
     SELECT
         c.change_category,
@@ -8430,7 +8511,8 @@ def report_workspace_identity_changes():
         c.console_url,
         CAST(c.event_time AS STRING)          AS event_time,
         CAST(c.detection_timestamp AS STRING) AS detection_timestamp,
-        c.auto_remediated
+        c.auto_remediated,
+        c.remediation_action
     FROM {WORKSPACE_IDENTITY_CHANGES_TABLE} c
     JOIN latest l ON c.run_id = l.run_id
     ORDER BY c.flagged DESC, c.event_time DESC
@@ -8438,7 +8520,7 @@ def report_workspace_identity_changes():
     """
 
     try:
-        results = exec_query_df(query)
+        results = exec_query_df(query, params=run_params)
     except NoAccessError:
         # No UC read grant on the findings table — let the access banner render.
         raise
@@ -8490,6 +8572,8 @@ def report_workspace_identity_changes():
         'metastores': metastores,
         'detection_timestamp': detection_timestamp,
         'workspaces': workspaces,
+        'runs': runs,
+        'selected_run_id': selected_run_id,
         'truncated': truncated,
         'row_cap': REPORT_ROW_CAP,
         'data': results,

--- a/app/brickhound/app.py
+++ b/app/brickhound/app.py
@@ -4096,15 +4096,28 @@ def get_main_html():
                 return `<option value="${escapeHtml(r.run_id)}"${r.run_id === sel ? ' selected' : ''}>${ts}</option>`;
             }).join('');
             if (!runs.length) runOpts = '<option value="">(latest)</option>';
-            const runSel = `<label style="font-size: 0.8em; color: var(--text-secondary);">Detection run</label>`
-                + `<select onchange="${cfg.runOnChange}" style="padding: 6px 10px; background: var(--bg-input); border: 1px solid var(--border); border-radius: 6px; color: var(--text-primary); font-size: 0.9em; cursor: pointer; max-width: 340px;">${runOpts}</select>`;
-            let filterSel = '';
+            // Match the global stats-header filters: card sections with small
+            // uppercase labels, separated by a divider.
+            const selStyle = 'padding: 6px 10px; background: var(--bg-input); border: 1px solid var(--border); border-radius: 6px; color: var(--text-primary); font-size: 0.9em; cursor: pointer; width: 100%;';
+            const runSection = `
+                <div class="stats-header-section" style="flex: 1; min-width: 240px;">
+                    <span class="stats-header-label">Detection Run</span>
+                    <select onchange="${cfg.runOnChange}" style="${selStyle} max-width: 340px;">${runOpts}</select>
+                </div>`;
+            let filterSection = '';
             if (cfg.filterScopeId) {
-                filterSel = `<label style="font-size: 0.8em; color: var(--text-secondary); margin-left: 16px;">Show</label>`
-                    + `<select onchange="applyRemFilter('${cfg.filterScopeId}', this.value)" style="padding: 6px 10px; background: var(--bg-input); border: 1px solid var(--border); border-radius: 6px; color: var(--text-primary); font-size: 0.9em; cursor: pointer;">`
-                    + `<option value="all">All</option><option value="true">Remediated</option><option value="false">Not remediated</option></select>`;
+                filterSection = `
+                    <div class="stats-header-divider"></div>
+                    <div class="stats-header-section" style="flex: 0 0 auto; min-width: 180px;">
+                        <span class="stats-header-label">Show</span>
+                        <select onchange="applyRemFilter('${cfg.filterScopeId}', this.value)" style="${selStyle} max-width: 220px;">
+                            <option value="all">All</option>
+                            <option value="true">Remediated</option>
+                            <option value="false">Not remediated</option>
+                        </select>
+                    </div>`;
             }
-            return `<div style="display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin-bottom: 16px;">${runSel}${filterSel}</div>`;
+            return `<div class="stats-header-row" style="flex-wrap: wrap; margin-bottom: 16px;">${runSection}${filterSection}</div>`;
         }
 
         // Client-side remediated filter: toggle leaf rows ([data-rem]) and hide any

--- a/app/brickhound/app.py
+++ b/app/brickhound/app.py
@@ -97,6 +97,14 @@ SHARED_TO_ACCOUNT_TABLE = f"`{CATALOG}`.`{SCHEMA}`.brickhound_shared_to_account"
 PRIVILEGED_NON_IDP_TABLE = f"`{CATALOG}`.`{SCHEMA}`.brickhound_privileged_non_idp"
 DENYLIST_CANDIDATES_TABLE = f"`{CATALOG}`.`{SCHEMA}`.brickhound_denylist_candidates"
 
+# Max rows any single report renders. Report queries fetch REPORT_ROW_CAP + 1 so
+# the endpoint can detect truncation; the extra row is trimmed before display.
+# This keeps the inline Statement Execution result well under its ~25 MB cap, so
+# a large account can never overflow the statement and surface as a false "no
+# findings" — instead the UI shows a "showing first N" banner. See exec_query_df,
+# which also follows result chunks so multi-chunk results aren't truncated.
+REPORT_ROW_CAP = 5000
+
 logger.info(f"[CONFIG FINAL] CATALOG={CATALOG}, SCHEMA={SCHEMA}")
 logger.info(f"[CONFIG FINAL] VERTICES_TABLE={VERTICES_TABLE}")
 logger.info(f"[CONFIG FINAL] EDGES_TABLE={EDGES_TABLE}")
@@ -346,27 +354,46 @@ def exec_query_df(sql_query, params=None):
         if sdk_params:
             kwargs["parameters"] = sdk_params
         result = workspace_client.statement_execution.execute_statement(**kwargs)
-        if hasattr(result, 'result') and result.result:
-            if hasattr(result.result, 'data_array') and result.result.data_array:
-                columns = []
-                try:
-                    if hasattr(result, 'manifest') and result.manifest:
-                        if hasattr(result.manifest, 'schema') and result.manifest.schema:
-                            for col in result.manifest.schema.columns:
-                                if hasattr(col, 'name'):
-                                    columns.append(col.name)
-                                elif isinstance(col, dict) and 'name' in col:
-                                    columns.append(col['name'])
-                except Exception:
-                    pass
-                rows = []
-                for row in result.result.data_array:
-                    if columns and len(columns) == len(row):
-                        rows.append(dict(zip(columns, row)))
-                    else:
-                        rows.append({f"col{i}": val for i, val in enumerate(row)})
-                return rows
-        return []
+
+        # Resolve column names once from the result manifest schema.
+        columns = []
+        try:
+            if getattr(result, 'manifest', None) and getattr(result.manifest, 'schema', None):
+                for col in result.manifest.schema.columns:
+                    if hasattr(col, 'name'):
+                        columns.append(col.name)
+                    elif isinstance(col, dict) and 'name' in col:
+                        columns.append(col['name'])
+        except Exception:
+            pass
+
+        rows = []
+
+        def _emit(chunk):
+            data = getattr(chunk, 'data_array', None) if chunk else None
+            if not data:
+                return
+            for row in data:
+                if columns and len(columns) == len(row):
+                    rows.append(dict(zip(columns, row)))
+                else:
+                    rows.append({f"col{i}": val for i, val in enumerate(row)})
+
+        # Statement Execution returns results in chunks; the first arrives inline
+        # on `result.result`. Follow `next_chunk_index` so large (multi-chunk)
+        # results aren't silently truncated to the first chunk — that would show
+        # as partial or "no" data in a security report.
+        chunk = getattr(result, 'result', None)
+        _emit(chunk)
+        statement_id = getattr(result, 'statement_id', None)
+        next_idx = getattr(chunk, 'next_chunk_index', None) if chunk else None
+        while statement_id is not None and next_idx is not None:
+            chunk = workspace_client.statement_execution.get_statement_result_chunk_n(
+                statement_id, next_idx)
+            _emit(chunk)
+            next_idx = getattr(chunk, 'next_chunk_index', None) if chunk else None
+
+        return rows
     except NoAccessError:
         raise
     except Exception as e:
@@ -3769,6 +3796,7 @@ def get_main_html():
                     : 'Account-wide (all IdP groups)';
 
                 let html = `
+                    ${renderTruncationBanner(result)}
                     ${renderCoverageBlock({
                         dateTs: detTs,
                         scopeLabel: 'Accounts',
@@ -4030,6 +4058,17 @@ def get_main_html():
                 </div>`;
         }
 
+        // Warn when a report was capped at row_cap rows so a large result is
+        // never mistaken for the full picture (or a false "no findings").
+        function renderTruncationBanner(result) {
+            if (!result || !result.truncated) return '';
+            const cap = result.row_cap || 5000;
+            return `<div style="background: rgba(245, 158, 11, 0.12); border: 1px solid var(--warning);`
+                + ` border-radius: 10px; padding: 12px 16px; margin-bottom: 16px; font-size: 0.9em; color: var(--text-primary);">`
+                + `⚠️ Showing the first ${cap.toLocaleString()} rows — this detection run has more findings than that.`
+                + ` Query the findings table directly for the complete set.</div>`;
+        }
+
         async function loadPrivilegedNonIdp() {
             const container = document.getElementById('privilegednonidp-results');
             container.innerHTML = '<div class="loading">Loading privileged non-IdP identities...</div>';
@@ -4066,6 +4105,7 @@ def get_main_html():
                 });
 
                 let html = `
+                    ${renderTruncationBanner(result)}
                     ${renderCoverageBlock({
                         dateTs: detTs,
                         scopeLabel: 'Workspaces',
@@ -4208,6 +4248,7 @@ def get_main_html():
                 const metastores = (result.metastores || []).map(m => ({name: m, reason: 'ok'}));
 
                 let html = `
+                    ${renderTruncationBanner(result)}
                     ${renderCoverageBlock({
                         dateTs: detTs,
                         scopeLabel: 'Metastores',
@@ -8020,12 +8061,16 @@ def report_shared_to_account():
     FROM {SHARED_TO_ACCOUNT_TABLE} s
     JOIN latest l ON s.run_id = l.run_id
     ORDER BY s.event_time DESC
+    LIMIT {REPORT_ROW_CAP + 1}
     """
 
     try:
         results = exec_query_df(query)
+    except NoAccessError:
+        # No UC read grant on the findings table — let the access banner render.
+        raise
     except Exception as e:
-        # Table absent (job never run) or no read grant — surface a friendly hint.
+        # Table absent (job never run) — surface a friendly hint.
         logger.warning("shared-to-account report query failed: %s", e)
         return jsonify({
             'error': (
@@ -8034,6 +8079,10 @@ def report_shared_to_account():
                 'notebooks/brickhound/05_share_to_account.py notebook) to populate it.'
             )
         })
+
+    truncated = len(results) > REPORT_ROW_CAP
+    if truncated:
+        results = results[:REPORT_ROW_CAP]
 
     # Statement Execution returns booleans as strings ('true'/'false'); normalize.
     for r in results:
@@ -8068,6 +8117,8 @@ def report_shared_to_account():
         'metastores': metastores,
         'detection_timestamp': detection_timestamp,
         'workspaces': workspaces,
+        'truncated': truncated,
+        'row_cap': REPORT_ROW_CAP,
         'data': results,
     })
 
@@ -8101,10 +8152,14 @@ def report_privileged_non_idp():
     FROM {PRIVILEGED_NON_IDP_TABLE} p
     JOIN latest l ON p.run_id = l.run_id
     ORDER BY p.finding_type, p.is_idp_managed, p.principal_name
+    LIMIT {REPORT_ROW_CAP + 1}
     """
 
     try:
         results = exec_query_df(query)
+    except NoAccessError:
+        # No UC read grant on the findings table — let the access banner render.
+        raise
     except Exception as e:
         logger.warning("privileged-non-idp report query failed: %s", e)
         return jsonify({
@@ -8114,6 +8169,10 @@ def report_privileged_non_idp():
                 'notebooks/brickhound/06_privileged_non_idp_identities.py notebook) to populate it.'
             )
         })
+
+    truncated = len(results) > REPORT_ROW_CAP
+    if truncated:
+        results = results[:REPORT_ROW_CAP]
 
     # Normalize boolean-ish string cells to real bools for the JS layer too,
     # so client-side conditionals (item.is_idp_managed) behave correctly.
@@ -8173,6 +8232,8 @@ def report_privileged_non_idp():
         'workspaces_scanned': scanned,
         'workspaces_failed': failed,
         'workspaces_in_report': in_report,
+        'truncated': truncated,
+        'row_cap': REPORT_ROW_CAP,
         'data': results,
     })
 
@@ -8203,10 +8264,14 @@ def report_denylist_candidates():
     FROM {DENYLIST_CANDIDATES_TABLE} c
     JOIN latest l ON c.run_id = l.run_id
     ORDER BY c.inactive_members DESC, c.inactive_pct DESC
+    LIMIT {REPORT_ROW_CAP + 1}
     """
 
     try:
         results = exec_query_df(query)
+    except NoAccessError:
+        # No UC read grant on the findings table — let the access banner render.
+        raise
     except Exception as e:
         logger.warning("denylist-candidates report query failed: %s", e)
         return jsonify({
@@ -8216,6 +8281,10 @@ def report_denylist_candidates():
                 'notebooks/brickhound/07_denylist_candidates.py notebook) to populate it.'
             )
         })
+
+    truncated = len(results) > REPORT_ROW_CAP
+    if truncated:
+        results = results[:REPORT_ROW_CAP]
 
     # Statement Execution returns everything as strings; normalize for the JS layer.
     for r in results:
@@ -8254,6 +8323,8 @@ def report_denylist_candidates():
         'inactive_days': inactive_days,
         'metastores': metastores,
         'account_id': account_id,
+        'truncated': truncated,
+        'row_cap': REPORT_ROW_CAP,
         'data': results,
     })
 

--- a/app/brickhound/app.py
+++ b/app/brickhound/app.py
@@ -2231,11 +2231,11 @@ def get_main_html():
                 </div>
             </div>
 
-            <!-- Workspace & Identity Changes Report Page -->
+            <!-- Workspace Identity Changes Report Page -->
             <div class="page" id="page-workspaceidentity">
                 <div class="page-header">
-                    <h1 class="page-title">Workspace &amp; Identity Changes</h1>
-                    <p class="page-desc">Identities created or changed outside the Automatic Identity Management sync (human, not the IdP), and non-IdP-managed identities assigned to workspaces. Flagged rows need review; assignments of IdP-managed identities and AIM-sync events are recorded as the governed baseline. Detected by the SAT workspace &amp; identity changes job.</p>
+                    <h1 class="page-title">Workspace Identity Changes</h1>
+                    <p class="page-desc">Identities created or changed outside the Automatic Identity Management sync (human, not the IdP), and non-IdP-managed identities assigned to workspaces. Flagged rows need review; assignments of IdP-managed identities and AIM-sync events are recorded as the governed baseline. Detected by the SAT workspace identity changes job.</p>
                 </div>
                 <div id="workspaceidentity-results"></div>
             </div>
@@ -4086,7 +4086,7 @@ def get_main_html():
 
         async function loadWorkspaceIdentityChanges() {
             const container = document.getElementById('workspaceidentity-results');
-            container.innerHTML = '<div class="loading">Loading workspace &amp; identity changes...</div>';
+            container.innerHTML = '<div class="loading">Loading workspace identity changes...</div>';
 
             try {
                 const res = await fetch('/api/report/workspace-identity-changes');
@@ -4178,7 +4178,7 @@ def get_main_html():
                         note: 'Detection is account-wide over the audit log (system.access.audit) of the metastore above; the entities in this report are the workspaces where changes were found.'
                     })}
                     <div style="background: var(--bg-input); border-radius: 12px; padding: 16px 20px; margin-bottom: 16px;">
-                        <div style="font-weight: 600; margin-bottom: 12px; color: var(--text-secondary);">Workspace &amp; Identity Changes</div>
+                        <div style="font-weight: 600; margin-bottom: 12px; color: var(--text-secondary);">Workspace Identity Changes</div>
                         <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(100px, 1fr)); gap: 12px; text-align: center;">
                             <div><div style="font-size: 1.8em; font-weight: 700; color: var(--accent);">${summary.total || 0}</div><div style="font-size: 0.75em; color: var(--text-muted); text-transform: uppercase;">Total</div></div>
                             <div><div style="font-size: 1.8em; font-weight: 700; color: #ef4444;">${summary.flagged || 0}</div><div style="font-size: 0.75em; color: var(--text-muted); text-transform: uppercase;">Flagged</div></div>
@@ -8437,7 +8437,7 @@ def report_workspace_identity_changes():
         return jsonify({
             'error': (
                 'No workspace/identity-change data available yet. Run the '
-                '"SAT Permissions Analysis - Workspace & Identity Changes" job (or the '
+                '"SAT Permissions Analysis - Workspace Identity Changes" job (or the '
                 'notebooks/brickhound/08_workspace_identity_changes.py notebook) to populate it.'
             )
         })

--- a/app/brickhound/app.py
+++ b/app/brickhound/app.py
@@ -2296,7 +2296,7 @@ def get_main_html():
             // data context yet) and the account-level detection pages, which have
             // their own run_id and per-report coverage block — showing the global
             // bar there only causes two-coverage-widget confusion.
-            const hideStatsBarPages = ['home', 'sharedtoaccount', 'privilegednonidp', 'denylistbuilder'];
+            const hideStatsBarPages = ['home', 'sharedtoaccount', 'privilegednonidp', 'denylistbuilder', 'workspaceidentity'];
             const statsBar = document.getElementById('stats-header-bar');
             if (statsBar) statsBar.style.display = hideStatsBarPages.includes(page) ? 'none' : '';
 

--- a/app/brickhound/app.py
+++ b/app/brickhound/app.py
@@ -4129,6 +4129,16 @@ def get_main_html():
                     const nameHtml = item.console_url
                         ? `<a href="${escapeHtml(item.console_url)}" target="_blank" rel="noopener noreferrer" style="color: var(--accent); text-decoration: none;">${who}</a>`
                         : who;
+                    // Explicit principal-type chip so a flagged "Identity created"
+                    // (or any row) shows at a glance whether it's a user, group, or SP.
+                    const typeMeta = {
+                        User: {emoji: '👤', label: 'User'},
+                        Group: {emoji: '👥', label: 'Group'},
+                        ServicePrincipal: {emoji: '🤖', label: 'Service Principal'},
+                        Unknown: {emoji: '❔', label: 'Unknown type'}
+                    };
+                    const tm = typeMeta[item.principal_type] || typeMeta.Unknown;
+                    const typeChip = `<span style="display: inline-block; background: var(--bg-dark); border: 1px solid var(--border); border-radius: 6px; padding: 1px 8px; font-size: 0.72em; font-weight: 600; text-transform: uppercase; letter-spacing: 0.4px; color: var(--text-secondary); margin-left: 8px; vertical-align: middle;">${tm.emoji} ${escapeHtml(tm.label)}</span>`;
                     const catLabel = catLabels[item.change_category] || item.change_category;
                     const idpBadge = item.principal_type === 'Unknown'
                         ? ' · <span style="color: var(--text-muted);">Unknown principal</span>'
@@ -4151,7 +4161,7 @@ def get_main_html():
                         <div style="display: flex; align-items: flex-start; gap: 12px; padding: 12px 24px; border-bottom: ${isLast ? 'none' : '1px solid var(--border)'};">
                             <span style="font-size: 16px;">${catEmoji[item.change_category] || '•'}</span>
                             <div style="flex: 1; min-width: 0;">
-                                <div style="font-weight: 500; word-break: break-word;">${nameHtml}</div>
+                                <div style="font-weight: 500; word-break: break-word;">${nameHtml}${typeChip}</div>
                                 <div style="font-size: 0.82em; color: var(--text-secondary); margin-top: 3px;">
                                     ${escapeHtml(catLabel)}${perm}${grp}${idpBadge}${aimBadge}${rem}
                                 </div>

--- a/dabs/dabs_template/template/tmp/resources/brickhound_job.yml.tmpl
+++ b/dabs/dabs_template/template/tmp/resources/brickhound_job.yml.tmpl
@@ -206,7 +206,7 @@ resources:
       {{- end }}
 
     brickhound_workspace_identity_changes:
-      name: "SAT Permissions Analysis - Workspace & Identity Changes (Experimental)"
+      name: "SAT Permissions Analysis - Workspace Identity Changes (Experimental)"
       tags:
         Application: SAT
       schedule:

--- a/dabs/dabs_template/template/tmp/resources/brickhound_job.yml.tmpl
+++ b/dabs/dabs_template/template/tmp/resources/brickhound_job.yml.tmpl
@@ -227,6 +227,7 @@ resources:
               last_n_days: "30"
               finding_scope: "workspace_assignment,account_workspace_access,identity_creation,group_membership,admin_grant"
               remediate: "no"
+              disable_identities: "no"
 
       {{- if eq .serverless false }}
       job_clusters:

--- a/dabs/dabs_template/template/tmp/resources/brickhound_job.yml.tmpl
+++ b/dabs/dabs_template/template/tmp/resources/brickhound_job.yml.tmpl
@@ -204,4 +204,48 @@ resources:
           spec:
             client: "5"
       {{- end }}
+
+    brickhound_workspace_identity_changes:
+      name: "SAT Permissions Analysis - Workspace & Identity Changes (Experimental)"
+      tags:
+        Application: SAT
+      schedule:
+        quartz_cron_expression: "0 0 6 ? * SUN"
+        timezone_id: {{.job_timezone}}
+      max_concurrent_runs: 1
+      timeout_seconds: 3600
+      tasks:
+        - task_key: "detect_workspace_identity_changes"
+          {{- if eq .serverless false }}
+          job_cluster_key: brickhound_workspace_identity_changes_cluster
+          {{- else }}
+          environment_key: "default"
+          {{- end }}
+          notebook_task:
+            notebook_path: "/Workspace/Applications/SAT/files/notebooks/brickhound/08_workspace_identity_changes"
+            base_parameters:
+              last_n_days: "30"
+              finding_scope: "workspace_assignment,account_workspace_access,identity_creation,group_membership,admin_grant"
+              remediate: "no"
+
+      {{- if eq .serverless false }}
+      job_clusters:
+        - job_cluster_key: brickhound_workspace_identity_changes_cluster
+          new_cluster:
+            data_security_mode: SINGLE_USER
+            num_workers: 3
+            spark_version: {{.latest_lts}}
+            runtime_engine: "PHOTON"
+            node_type_id: {{.node_type}}
+            {{- if eq .cloud "aws" }}
+            aws_attributes:
+              availability: SPOT_WITH_FALLBACK
+              first_on_demand: 1
+            {{- end }}
+      {{- else }}
+      environments:
+        - environment_key: "default"
+          spec:
+            client: "5"
+      {{- end }}
 {{- end }}

--- a/notebooks/brickhound/07_denylist_candidates.py
+++ b/notebooks/brickhound/07_denylist_candidates.py
@@ -21,6 +21,13 @@
 # MAGIC     IS available via SCIM (e.g. traditional SCIM-provisioned groups). For AIM accounts, use the
 # MAGIC     Entra ID dynamic-group rule helper in the app tab to build denylist groups instead.
 # MAGIC   </p>
+# MAGIC   <p style="margin: 8px 0 0 0; font-size: 0.8em; color: #d32f2f;">
+# MAGIC     <b>Zero-member groups are excluded by default.</b> Because AIM makes a populated external group
+# MAGIC     look empty via SCIM (identical to a genuinely empty group), reporting zero-member groups as
+# MAGIC     "safe to deny" would produce dangerous false positives on AIM accounts. Set the
+# MAGIC     <code>include_zero_member_groups</code> widget to <code>yes</code> only on accounts whose IdP
+# MAGIC     group membership is genuinely resolvable via SCIM.
+# MAGIC   </p>
 # MAGIC </div>
 # MAGIC
 # MAGIC ## What This Analysis Does
@@ -54,11 +61,20 @@
 # DBTITLE 1,Define Widgets
 dbutils.widgets.text("inactive_days", "90", "Inactive threshold (days without activity)")
 dbutils.widgets.text("min_inactive", "1", "Minimum inactive members to report a group")
+dbutils.widgets.dropdown("include_zero_member_groups", "no", ["no", "yes"],
+                         "Include zero-member IdP groups")
 
-INACTIVE_DAYS = int(dbutils.widgets.get("inactive_days"))
-MIN_INACTIVE  = int(dbutils.widgets.get("min_inactive"))
+INACTIVE_DAYS        = int(dbutils.widgets.get("inactive_days"))
+MIN_INACTIVE         = int(dbutils.widgets.get("min_inactive"))
+# Zero-member IdP groups are excluded by default: under Automatic Identity
+# Management, account SCIM returns members EMPTY for external groups even when
+# they are full of active users (see the AIM note at the top). Emitting those as
+# "safe to deny" is a dangerous false positive on AIM accounts. Enable this only
+# on accounts whose IdP group membership is genuinely resolvable via SCIM.
+INCLUDE_ZERO_MEMBER  = dbutils.widgets.get("include_zero_member_groups") == "yes"
 print(f"Inactive threshold: {INACTIVE_DAYS} days")
 print(f"Min inactive members to report: {MIN_INACTIVE}")
+print(f"Include zero-member IdP groups: {INCLUDE_ZERO_MEMBER}")
 
 # COMMAND ----------
 
@@ -189,6 +205,7 @@ def is_inactive(user: dict) -> bool:
 # the built-in 'account users' group and any local/system groups.
 rows = []
 skipped_local = 0
+skipped_zero_member = 0
 for g in groups:
     if not g.get("externalId"):
         skipped_local += 1
@@ -208,14 +225,22 @@ for g in groups:
         if is_inactive(u):
             inactive_members += 1
 
-    # An IdP group is a denylist candidate if it has inactive members OR has no
-    # user members at all. A zero-member group is a strong candidate: an IdP
-    # group with no active Databricks users is safe to deny. (Under AIM, SCIM
-    # returns members empty for external groups, so most land here — see the AIM
-    # note above.)
-    if inactive_members >= MIN_INACTIVE or total_members == 0:
+    is_zero_member = total_members == 0
+    # Zero-member groups are ambiguous: a genuinely empty IdP group is a strong
+    # denylist candidate, BUT under AIM a populated external group also returns
+    # zero members via SCIM (see the AIM note above). We cannot tell the two
+    # apart from SCIM alone, so we exclude zero-member groups unless the operator
+    # explicitly opts in — otherwise this report would flag active-user groups as
+    # "safe to deny" on AIM accounts.
+    if is_zero_member and not INCLUDE_ZERO_MEMBER:
+        skipped_zero_member += 1
+        continue
+
+    # An IdP group is a denylist candidate if it has enough inactive members, or
+    # (only when opted in) has no user members at all.
+    if inactive_members >= MIN_INACTIVE or is_zero_member:
         gid = str(g["id"])
-        reason = "no members via SCIM" if total_members == 0 else "has inactive members"
+        reason = "no members via SCIM" if is_zero_member else "has inactive members"
         rows.append({
             "group_id":         gid,
             "group_name":       g.get("displayName"),
@@ -234,7 +259,11 @@ candidates = pd.DataFrame(rows).sort_values(
     ["inactive_members", "inactive_pct"], ascending=False
 ) if rows else pd.DataFrame()
 print(f"Skipped {skipped_local} local/non-IdP group(s) (not denylist-eligible).")
-print(f"Candidate IdP groups (inactive members or zero members): {len(candidates)}")
+if not INCLUDE_ZERO_MEMBER and skipped_zero_member:
+    print(f"Skipped {skipped_zero_member} zero-member IdP group(s) "
+          f"(excluded by default — set include_zero_member_groups=yes to include; "
+          f"unreliable under AIM).")
+print(f"Candidate IdP groups: {len(candidates)}")
 
 # COMMAND ----------
 

--- a/notebooks/brickhound/08_workspace_identity_changes.py
+++ b/notebooks/brickhound/08_workspace_identity_changes.py
@@ -1,0 +1,676 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # Workspace & Identity Changes — Detection & Remediation
+# MAGIC *Catch identities introduced outside your IdP, and non-IdP identities assigned to workspaces*
+# MAGIC
+# MAGIC <div style="background-color: #fff3e0; border-left: 4px solid #d32f2f; padding: 12px; margin: 16px 0;">
+# MAGIC   <p style="margin: 0; font-size: 0.85em; color: #d32f2f; font-weight: bold;">⚠️ DISCLAIMER</p>
+# MAGIC   <p style="margin: 8px 0 0 0; font-size: 0.8em; color: #555;">
+# MAGIC     This tool may have incomplete data. Outputs are visibility and audit aids, not authoritative
+# MAGIC     compliance determinations. Remediation (removing a workspace permission assignment) is a
+# MAGIC     <b>destructive, opt-in</b> action — review findings before enabling it.
+# MAGIC   </p>
+# MAGIC </div>
+# MAGIC
+# MAGIC ## What This Analysis Does
+# MAGIC
+# MAGIC With **Automatic Identity Management (AIM)**, identities and group memberships should originate
+# MAGIC from your identity provider (Entra ID), provisioned automatically. Two things break that model:
+# MAGIC
+# MAGIC 1. **A human creates or changes an identity outside the IdP sync** — e.g. an admin hand-creates a
+# MAGIC    user/group/service principal, adds a member to a group, or grants account admin. Identities
+# MAGIC    should come from the IdP, not be created directly in Databricks.
+# MAGIC 2. **A non-IdP-managed identity is assigned to a workspace** — assigning identities to workspaces is
+# MAGIC    a legitimate, necessary Databricks operation (it *cannot* be done by the IdP), but the thing
+# MAGIC    being assigned should be an **IdP-managed** identity.
+# MAGIC
+# MAGIC This notebook reads `system.access.audit` and flags both. It **distinguishes human actions from the
+# MAGIC AIM sync process**: AIM tags its automated events with `request_params.endpoint = 'autoUserCreation'`,
+# MAGIC so any identity change *without* that tag was performed by a human.
+# MAGIC
+# MAGIC | Category | Source action(s) | Flagged when |
+# MAGIC |---|---|---|
+# MAGIC | `identity_created` | `add`, `createGroup` (accounts) | performed by a human (not AIM sync) |
+# MAGIC | `group_membership_add` | `addPrincipalToGroup(s)` (accounts) | performed by a human (not AIM sync) |
+# MAGIC | `admin_grant` | `setAdmin` (accounts) | performed by a human (not AIM sync) |
+# MAGIC | `workspace_assignment_add` | `updatePermissionAssignment` (workspace) | assigned principal is **not** IdP-managed |
+# MAGIC | `account_workspace_access` | `changeDatabricksWorkspaceAcl` (accounts) | assigned principal is **not** IdP-managed |
+# MAGIC | `workspace_assignment_remove` | `deletePermissionAssignment` (workspace) | never (recorded for context) |
+# MAGIC
+# MAGIC AIM-sync events and assignments of IdP-managed identities are **recorded but not flagged** — they are
+# MAGIC the expected, governed baseline. What SAT proves is *that an ungoverned-looking change happened, and
+# MAGIC who/when* — it cannot by itself prove whether an Entra entitlement-management approval backed it.
+# MAGIC
+# MAGIC ### Scope of the two admin paths
+# MAGIC
+# MAGIC - **Workspace admins** assigning identities via the workspace UI → `updatePermissionAssignment`
+# MAGIC   (service `workspace`). Fires for **users, groups, and service principals**.
+# MAGIC - **Account admins** assigning identities via the account console → `changeDatabricksWorkspaceAcl`
+# MAGIC   (service `accounts`).
+# MAGIC
+# MAGIC Findings are written to **`brickhound_workspace_identity_changes`** in SAT's analysis schema, stamped
+# MAGIC with a `run_id`. The SAT Permissions Analysis app reads this table to surface findings in the UI.
+# MAGIC
+# MAGIC ## Prerequisites
+# MAGIC
+# MAGIC - SAT installed (`sat_scope` with `account-console-id`, `client-id`, `client-secret`,
+# MAGIC   `analysis_schema_name`); service principal with **Account Admin**.
+# MAGIC - Access to `system.access.audit` and `system.access.workspaces_latest`.
+# MAGIC - **Azure only:** the compute needs network egress to `login.microsoftonline.com` (Entra ID) for
+# MAGIC   MSAL token minting. If serverless egress is restricted, run on a classic cluster.
+
+# COMMAND ----------
+
+# DBTITLE 1,Run Configuration
+# MAGIC %run ./00_config
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Configuration Widgets
+# MAGIC
+# MAGIC | Widget | Description |
+# MAGIC |---|---|
+# MAGIC | `last_n_days` | How far back to search the audit log (default 30). |
+# MAGIC | `finding_scope` | Comma-separated: `workspace_assignment`, `account_workspace_access`, `identity_creation`, `group_membership`, `admin_grant`. |
+# MAGIC | `remediate` | `yes` removes the workspace permission assignment for flagged non-IdP assignments. Default `no` (report-only). |
+
+# COMMAND ----------
+
+# DBTITLE 1,Define Widgets
+dbutils.widgets.text("last_n_days", "30", "Look-back window (days)")
+dbutils.widgets.text(
+    "finding_scope",
+    "workspace_assignment,account_workspace_access,identity_creation,group_membership,admin_grant",
+    "Finding scope (comma-separated)",
+)
+dbutils.widgets.dropdown("remediate", "no", ["no", "yes"], "Remove non-IdP workspace assignments")
+
+LAST_N_DAYS   = int(dbutils.widgets.get("last_n_days"))
+FINDING_SCOPE = [s.strip() for s in dbutils.widgets.get("finding_scope").split(",") if s.strip()]
+REMEDIATE     = dbutils.widgets.get("remediate") == "yes"
+
+print(f"Look-back window: {LAST_N_DAYS} days")
+print(f"Finding scope:    {FINDING_SCOPE}")
+print(f"Remediate:        {REMEDIATE}")
+
+# COMMAND ----------
+
+# DBTITLE 1,Resolve Account Host, Credentials, and Output Table
+# Mirrors core/dbclient.py: derive the accounts host per cloud, honoring the
+# accounts_console override for GovCloud/DoD.
+
+def _domain_from_url(url: str) -> str:
+    host = url.split("://")[-1].split("/")[0]
+    return host.split(".")[-1] if "." in host else "com"
+
+def resolve_accounts_host(cloud: str, workspace_url: str, override: str = "") -> str:
+    if override:
+        return override.rstrip("/")
+    domain = _domain_from_url(workspace_url)
+    if cloud == "aws":
+        return f"https://accounts.cloud.databricks.{domain}"
+    elif cloud == "gcp":
+        return f"https://accounts.gcp.databricks.{domain}"
+    elif cloud == "azure":
+        return f"https://accounts.azuredatabricks.{domain}"
+    raise ValueError(f"Unsupported cloud type: '{cloud}'")
+
+WORKSPACE_URL = (
+    dbutils.notebook.entry_point.getDbutils().notebook().getContext().apiUrl().getOrElse(None)
+)
+ACCOUNTS_HOST = resolve_accounts_host(cloud_type, WORKSPACE_URL, json_.get("accounts_console", ""))
+ACCOUNT_ID    = json_["account_id"]
+CLIENT_ID     = dbutils.secrets.get(scope=SECRETS_SCOPE, key="client-id")
+CLIENT_SECRET = dbutils.secrets.get(scope=SECRETS_SCOPE, key="client-secret")
+
+# tenant-id is required for Azure (Entra/MSAL auth); absent on AWS/GCP.
+TENANT_ID = None
+if cloud_type == "azure":
+    TENANT_ID = json_.get("tenant_id") or dbutils.secrets.get(scope=SECRETS_SCOPE, key="tenant-id")
+
+WORKSPACE_IDENTITY_CHANGES_TABLE = f"{CATALOG}.{SCHEMA}.brickhound_workspace_identity_changes"
+
+print(f"Cloud type:    {cloud_type}")
+print(f"Accounts host: {ACCOUNTS_HOST}")
+print(f"Output table:  {WORKSPACE_IDENTITY_CHANGES_TABLE}")
+
+# COMMAND ----------
+
+# DBTITLE 1,Auditor Implementation
+from __future__ import annotations
+
+import urllib.parse
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import pandas as pd
+import requests
+from pyspark.sql import functions as F
+
+# Tag SAT's direct REST traffic so it is attributed to SAT usage in Databricks
+# telemetry, matching core/dbclient.py and the other SAT notebooks.
+SAT_USER_AGENT = "databricks-sat/0.1.0"
+
+# Audit action_name -> (change_category, changed_via, principal_id key, permission key)
+# Verified against the live system.access.audit table. request_params is a MAP, so
+# absent keys resolve to NULL (no "cannot find field" error).
+_SCOPE_ACTIONS = {
+    "workspace_assignment": [
+        ("updatePermissionAssignment", "workspace_assignment_add",    "workspace_admin"),
+        ("deletePermissionAssignment", "workspace_assignment_remove", "workspace_admin"),
+    ],
+    "account_workspace_access": [
+        ("changeDatabricksWorkspaceAcl", "account_workspace_access", "account_admin"),
+    ],
+    "identity_creation": [
+        ("add",         "identity_created", "account_admin"),
+        ("createGroup", "identity_created", "account_admin"),
+    ],
+    "group_membership": [
+        ("addPrincipalToGroup",  "group_membership_add", "account_admin"),
+        ("addPrincipalsToGroup", "group_membership_add", "account_admin"),
+    ],
+    "admin_grant": [
+        ("setAdmin", "admin_grant", "account_admin"),
+    ],
+}
+
+
+@dataclass(frozen=True)
+class RemediationResult:
+    workspace_id: str
+    principal_id: str
+    success:      bool
+    message:      str
+
+    def __str__(self) -> str:
+        icon = "✓" if self.success else "✗"
+        return f"{icon} ws={self.workspace_id} principal={self.principal_id}: {self.message}"
+
+
+class WorkspaceIdentityChangeAuditor:
+    """Detect (and optionally remediate) workspace/identity changes from the audit
+    log: identities created/changed outside the AIM sync, and non-IdP identities
+    assigned to workspaces.
+    """
+
+    def __init__(self, accounts_host: str, account_id: str, client_id: str,
+                 client_secret: str, cloud_type: str, tenant_id: Optional[str] = None,
+                 proxies: Optional[dict] = None) -> None:
+        self._accounts_host = accounts_host.rstrip("/")
+        self._account_id    = account_id
+        self._client_id     = client_id
+        self._client_secret = client_secret
+        self._cloud_type    = cloud_type
+        self._tenant_id     = tenant_id
+        self._proxies       = proxies or {}
+        self._acct_token    = self._mint_account_token()
+        self._acct_hdrs     = {"Authorization": f"Bearer {self._acct_token}",
+                               "User-Agent": SAT_USER_AGENT}
+
+    # ── Token helpers ────────────────────────────────────────────────────────
+
+    def _mint_azure_msal_token(self) -> str:
+        """AAD token for the Databricks resource (matches SatDBClient.getAzureTokenWithMSAL)."""
+        import msal
+        app = msal.ConfidentialClientApplication(
+            client_id=self._client_id,
+            client_credential=self._client_secret,
+            authority=f"https://login.microsoftonline.com/{self._tenant_id}",
+        )
+        token = app.acquire_token_for_client(scopes=["2ff814a6-3304-4ab8-85cb-cd0e6f879c1d/.default"])
+        if not token or not token.get("access_token"):
+            raise Exception(f"MSAL token acquisition failed: {token.get('error_description') if token else 'no token'}")
+        return token["access_token"]
+
+    def _mint_account_token(self) -> str:
+        if self._cloud_type == "azure":
+            return self._mint_azure_msal_token()
+        resp = requests.post(
+            f"{self._accounts_host}/oidc/accounts/{self._account_id}/v1/token",
+            headers={"Content-Type": "application/x-www-form-urlencoded",
+                     "User-Agent": SAT_USER_AGENT},
+            data={
+                "grant_type":    "client_credentials",
+                "client_id":     self._client_id,
+                "client_secret": self._client_secret,
+                "scope":         "all-apis",
+            },
+            proxies=self._proxies,
+        )
+        resp.raise_for_status()
+        return resp.json()["access_token"]
+
+    # ── SCIM enrichment ──────────────────────────────────────────────────────
+
+    def _scim_list(self, resource: str, attributes: str) -> list[dict]:
+        """Page through an account SCIM collection (Groups/Users/ServicePrincipals)."""
+        items: list[dict] = []
+        start_index, count = 1, 100
+        while True:
+            resp = requests.get(
+                f"{self._accounts_host}/api/2.0/accounts/{self._account_id}/scim/v2/{resource}"
+                f"?attributes={urllib.parse.quote(attributes)}&startIndex={start_index}&count={count}",
+                headers=self._acct_hdrs,
+                proxies=self._proxies,
+            )
+            resp.raise_for_status()
+            body = resp.json()
+            page = body.get("Resources", [])
+            items.extend(page)
+            total = body.get("totalResults", len(items))
+            if start_index + count > total or not page:
+                break
+            start_index += count
+        return items
+
+    def build_identity_index(self) -> dict[str, dict]:
+        """Map account SCIM id -> {principal_type, principal_name, principal_email,
+        application_id, is_idp_managed}. Used to enrich the principal in each audit
+        event (the audit log records only the principal_id, not its type)."""
+        index: dict[str, dict] = {}
+        specs = [
+            ("Users",             "User",             "id,userName,displayName,externalId"),
+            ("Groups",            "Group",            "id,displayName,externalId"),
+            ("ServicePrincipals", "ServicePrincipal", "id,applicationId,displayName,externalId"),
+        ]
+        for resource, ptype, attrs in specs:
+            for e in self._scim_list(resource, attrs):
+                index[str(e.get("id"))] = {
+                    "principal_type":  ptype,
+                    "principal_name":  e.get("displayName") or e.get("userName") or e.get("applicationId"),
+                    "principal_email": e.get("userName") if ptype == "User" else None,
+                    "application_id":  e.get("applicationId") if ptype == "ServicePrincipal" else None,
+                    "is_idp_managed":  bool(e.get("externalId")),
+                }
+        return index
+
+    def _console_url(self, principal_type: Optional[str]) -> str:
+        segment = {"Group": "groups", "User": "users",
+                   "ServicePrincipal": "serviceprincipals"}.get(principal_type or "", "users")
+        return f"{self._accounts_host}/user-management/{segment}"
+
+    # ── Detection ──────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _subquery(action: str, category: str, changed_via: str, since: str) -> str:
+        """One UNION ALL branch. Columns are positional and identical across
+        branches; principal-id / permission / hint keys differ per action."""
+        # principal-id and permission keys per action (verified live)
+        if action in ("updatePermissionAssignment", "deletePermissionAssignment"):
+            pid_expr  = "request_params['principal_id']"
+            perm_expr = "request_params['permissions']" if action == "updatePermissionAssignment" else "CAST(NULL AS STRING)"
+            hint_expr = "CAST(NULL AS STRING)"
+            grp_expr  = "CAST(NULL AS STRING)"
+            ws_expr   = "coalesce(request_params['workspace_id'], CAST(workspace_id AS STRING))"
+            extra     = ""
+        elif action == "changeDatabricksWorkspaceAcl":
+            pid_expr  = "request_params['targetUserId']"
+            perm_expr = "request_params['aclPermissionSet']"
+            hint_expr = "CAST(NULL AS STRING)"
+            grp_expr  = "CAST(NULL AS STRING)"
+            ws_expr   = "CAST(workspace_id AS STRING)"
+            # Only grants (non-empty permission set); empty = a revoke.
+            extra     = "AND request_params['aclPermissionSet'] != ''"
+        elif action == "createGroup":
+            pid_expr  = "request_params['targetGroupId']"
+            perm_expr = "CAST(NULL AS STRING)"
+            hint_expr = "request_params['targetGroupName']"
+            grp_expr  = "CAST(NULL AS STRING)"
+            ws_expr   = "CAST(workspace_id AS STRING)"
+            extra     = ""
+        elif action in ("addPrincipalToGroup", "addPrincipalsToGroup"):
+            pid_expr  = "request_params['targetUserId']"
+            perm_expr = "CAST(NULL AS STRING)"
+            hint_expr = "request_params['targetUserName']"
+            grp_expr  = "request_params['targetGroupName']"
+            ws_expr   = "CAST(workspace_id AS STRING)"
+            extra     = ""
+        elif action == "setAdmin":
+            pid_expr  = "request_params['targetUserId']"
+            perm_expr = "'account_admin'"
+            hint_expr = "request_params['targetUserName']"
+            grp_expr  = "CAST(NULL AS STRING)"
+            ws_expr   = "CAST(workspace_id AS STRING)"
+            extra     = ""
+        else:  # add (user/SP created)
+            pid_expr  = "request_params['targetUserId']"
+            perm_expr = "CAST(NULL AS STRING)"
+            hint_expr = "request_params['targetUserName']"
+            grp_expr  = "CAST(NULL AS STRING)"
+            ws_expr   = "CAST(workspace_id AS STRING)"
+            extra     = ""
+
+        service = "workspace" if changed_via == "workspace_admin" else "accounts"
+        return f"""
+            SELECT
+                '{category}'    AS change_category,
+                '{changed_via}' AS changed_via,
+                event_time,
+                event_date,
+                {ws_expr}       AS workspace_id,
+                action_name,
+                service_name,
+                user_identity.email AS actor_email,
+                source_ip_address   AS source_ip,
+                {pid_expr}      AS principal_id,
+                {perm_expr}     AS permission,
+                request_params['endpoint'] AS endpoint,
+                {hint_expr}     AS principal_hint,
+                {grp_expr}      AS related_group
+            FROM system.access.audit
+            WHERE action_name = '{action}' AND service_name = '{service}'
+              {extra}
+              AND event_time >= '{since}'
+        """
+
+    def query_events(self, last_n_days: int, scopes: list[str]) -> pd.DataFrame:
+        since = (datetime.now(timezone.utc) - timedelta(days=last_n_days)).strftime("%Y-%m-%d")
+        branches: list[str] = []
+        for scope in scopes:
+            for action, category, changed_via in _SCOPE_ACTIONS.get(scope, []):
+                branches.append(self._subquery(action, category, changed_via, since))
+        if not branches:
+            return pd.DataFrame()
+
+        union = " UNION ALL ".join(branches)
+        sql = f"""
+            SELECT e.*, w.workspace_name
+            FROM ( {union} ) e
+            LEFT JOIN system.access.workspaces_latest w
+                   ON e.workspace_id = CAST(w.workspace_id AS STRING)
+                  AND w.status = 'RUNNING'
+            ORDER BY e.event_time DESC
+        """
+        return spark.sql(sql).toPandas()
+
+    def classify(self, df: pd.DataFrame, index: dict[str, dict]) -> pd.DataFrame:
+        """Enrich each event's principal from SCIM and apply the flag model."""
+        if df.empty:
+            return df
+
+        def enrich(row):
+            info = index.get(str(row["principal_id"])) if row.get("principal_id") else None
+            if info:
+                ptype, pname = info["principal_type"], info["principal_name"]
+                pemail, app_id, idp = info["principal_email"], info["application_id"], info["is_idp_managed"]
+            else:
+                # Principal not in current SCIM (deleted since, or unknown) — fall
+                # back to the name captured in the audit event.
+                ptype, pname = "Unknown", row.get("principal_hint")
+                pemail, app_id, idp = None, None, False
+            return pd.Series({
+                "principal_type":  ptype,
+                "principal_name":  pname,
+                "principal_email": pemail,
+                "application_id":  app_id,
+                "is_idp_managed":  idp,
+                "console_url":     self._console_url(ptype),
+            })
+
+        df = df.copy()
+        df[["principal_type", "principal_name", "principal_email", "application_id",
+            "is_idp_managed", "console_url"]] = df.apply(enrich, axis=1)
+        df["is_aim_sync"] = df["endpoint"] == "autoUserCreation"
+
+        def flag(row):
+            cat, aim, idp = row["change_category"], row["is_aim_sync"], row["is_idp_managed"]
+            if cat == "identity_created":
+                return (not aim, "ungoverned_identity_creation" if not aim else None)
+            if cat == "group_membership_add":
+                return (not aim, "ungoverned_group_membership" if not aim else None)
+            if cat == "admin_grant":
+                return (not aim, "ungoverned_admin_grant" if not aim else None)
+            if cat in ("workspace_assignment_add", "account_workspace_access"):
+                return ((not idp), "workspace_assignment_of_non_idp_identity" if not idp else None)
+            return (False, None)  # workspace_assignment_remove, etc.
+
+        flags = df.apply(flag, axis=1, result_type="expand")
+        df["flagged"], df["flag_reason"] = flags[0].astype(bool), flags[1]
+        df["auto_remediated"] = False
+        return df
+
+    # ── Remediation ────────────────────────────────────────────────────────────
+
+    def _remove_workspace_assignment(self, workspace_id: str, principal_id: str) -> RemediationResult:
+        """Account-scoped DELETE of a principal's workspace permission assignment.
+
+        Removes the principal's access to THAT workspace only; the account-level
+        identity and any other-workspace access are untouched. Account-scoped so it
+        needs no per-workspace token and is immune to cross-workspace enforcement.
+        """
+        url = (f"{self._accounts_host}/api/2.0/accounts/{self._account_id}"
+               f"/workspaces/{workspace_id}/permissionassignments/principals/{principal_id}")
+        try:
+            resp = requests.delete(url, headers=self._acct_hdrs, proxies=self._proxies, timeout=30)
+        except requests.RequestException as e:
+            return RemediationResult(workspace_id, principal_id, False, f"{type(e).__name__}")
+        if resp.ok or resp.status_code == 404:  # 404 = assignment already gone
+            return RemediationResult(workspace_id, principal_id, True,
+                                     "assignment removed" if resp.ok else "already removed")
+        return RemediationResult(workspace_id, principal_id, False,
+                                 f"DELETE {resp.status_code}: {resp.text[:200]}")
+
+    def remediate(self, df: pd.DataFrame, max_workers: int = 8) -> list[RemediationResult]:
+        """Remove workspace assignments for FLAGGED non-IdP assignment findings.
+
+        Only `workspace_assignment_add` / `account_workspace_access` are remediated
+        (removing a workspace permission assignment is safe and reversible).
+        Ungoverned identity creation / membership / admin grants are left for manual
+        review — undoing them means deleting the account identity, which is too
+        destructive to automate here.
+        """
+        targets = df[
+            df["flagged"]
+            & df["change_category"].isin(["workspace_assignment_add", "account_workspace_access"])
+            & df["workspace_id"].notna()
+            & df["principal_id"].notna()
+        ].drop_duplicates(["workspace_id", "principal_id"])
+
+        if targets.empty:
+            print("  No flagged workspace assignments to remediate.")
+            return []
+
+        results: list[RemediationResult] = []
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = {
+                pool.submit(self._remove_workspace_assignment,
+                            str(row["workspace_id"]), str(row["principal_id"])): None
+                for _, row in targets.iterrows()
+            }
+            for future in as_completed(futures):
+                results.append(future.result())
+
+        for r in sorted(results, key=lambda r: (r.workspace_id, r.principal_id)):
+            print(r)
+        return results
+
+# COMMAND ----------
+
+# DBTITLE 1,Initialize Auditor & Build Identity Index
+auditor = WorkspaceIdentityChangeAuditor(
+    accounts_host = ACCOUNTS_HOST,
+    account_id    = ACCOUNT_ID,
+    client_id     = CLIENT_ID,
+    client_secret = CLIENT_SECRET,
+    cloud_type    = cloud_type,
+    tenant_id     = TENANT_ID,
+    proxies       = json_.get("proxies", {}),
+)
+identity_index = auditor.build_identity_index()
+print(f"✓ Auditor initialized; account SCIM identity index: {len(identity_index)} principals")
+
+# COMMAND ----------
+
+# DBTITLE 1,Detect Changes
+raw = auditor.query_events(LAST_N_DAYS, FINDING_SCOPE)
+print(f"Found {len(raw)} identity/assignment event(s) in the last {LAST_N_DAYS} days.")
+
+findings = auditor.classify(raw, identity_index)
+if not findings.empty:
+    flagged_n = int(findings["flagged"].sum())
+    print(f"Flagged (require review): {flagged_n} of {len(findings)}")
+    print(findings.groupby(["change_category", "flagged"]).size().to_string())
+
+# COMMAND ----------
+
+# DBTITLE 1,Remediate (opt-in)
+if REMEDIATE and not findings.empty:
+    print("Remediating flagged non-IdP workspace assignments...\n")
+    results = auditor.remediate(findings)
+    ok = {(r.workspace_id, r.principal_id) for r in results if r.success}
+    findings["auto_remediated"] = findings.apply(
+        lambda x: (str(x["workspace_id"]), str(x["principal_id"])) in ok
+                  and x["change_category"] in ("workspace_assignment_add", "account_workspace_access")
+                  and bool(x["flagged"]),
+        axis=1,
+    )
+    other_flagged = int((findings["flagged"] & ~findings["change_category"].isin(
+        ["workspace_assignment_add", "account_workspace_access"])).sum())
+    if other_flagged:
+        print(f"\nℹ {other_flagged} flagged identity/membership/admin change(s) not auto-remediated "
+              "(review and remove the identity/role at the account level manually).")
+elif REMEDIATE:
+    print("Remediation enabled, but no findings to remediate.")
+else:
+    print("Remediation not enabled — set the 'remediate' widget to 'yes' to take action.")
+
+# COMMAND ----------
+
+# DBTITLE 1,Persist Findings to Delta
+import uuid
+from pyspark.sql.types import (
+    StructType, StructField, StringType, TimestampType, BooleanType, DateType,
+)
+
+RUN_ID = datetime.now().strftime("%Y%m%d_%H%M%S") + "_" + str(uuid.uuid4())[:8]
+DETECTION_TIME = datetime.now(timezone.utc)
+print(f"Run ID: {RUN_ID}")
+
+findings_schema = StructType([
+    StructField("run_id",              StringType(),    False),
+    StructField("detection_timestamp", TimestampType(), False),
+    StructField("event_time",          TimestampType(), True),
+    StructField("event_date",          DateType(),      True),
+    StructField("action_name",         StringType(),    True),
+    StructField("change_category",     StringType(),    True),
+    StructField("changed_via",         StringType(),    True),
+    StructField("is_aim_sync",         BooleanType(),   True),
+    StructField("actor_email",         StringType(),    True),
+    StructField("source_ip",           StringType(),    True),
+    StructField("principal_id",        StringType(),    True),
+    StructField("principal_type",      StringType(),    True),
+    StructField("principal_name",      StringType(),    True),
+    StructField("principal_email",     StringType(),    True),
+    StructField("application_id",      StringType(),    True),
+    StructField("is_idp_managed",      BooleanType(),   True),
+    StructField("related_group",       StringType(),    True),
+    StructField("permission",          StringType(),    True),
+    StructField("workspace_id",        StringType(),    True),
+    StructField("workspace_name",      StringType(),    True),
+    StructField("flagged",             BooleanType(),   True),
+    StructField("flag_reason",         StringType(),    True),
+    StructField("console_url",         StringType(),    True),
+    StructField("auto_remediated",     BooleanType(),   True),
+])
+
+_cols = [
+    "run_id", "detection_timestamp", "event_time", "event_date", "action_name",
+    "change_category", "changed_via", "is_aim_sync", "actor_email", "source_ip",
+    "principal_id", "principal_type", "principal_name", "principal_email", "application_id",
+    "is_idp_managed", "related_group", "permission", "workspace_id", "workspace_name",
+    "flagged", "flag_reason", "console_url", "auto_remediated",
+]
+
+if findings.empty:
+    findings_df = spark.createDataFrame([], schema=findings_schema)
+else:
+    out = findings.copy()
+    out["run_id"]              = RUN_ID
+    out["detection_timestamp"] = DETECTION_TIME
+    out["workspace_id"]        = out["workspace_id"].astype("object").where(out["workspace_id"].notna(), None)
+    out["principal_id"]        = out["principal_id"].astype("object").where(out["principal_id"].notna(), None)
+    # Coerce numpy.bool_ -> python bool; some Spark versions reject numpy.bool_
+    # against a BooleanType schema column.
+    for _b in ("is_aim_sync", "is_idp_managed", "flagged", "auto_remediated"):
+        out[_b] = out[_b].map(bool)
+    findings_df = spark.createDataFrame(out[_cols], schema=findings_schema)
+
+findings_df.write.format("delta").mode("append") \
+    .option("mergeSchema", "true") \
+    .saveAsTable(WORKSPACE_IDENTITY_CHANGES_TABLE)
+
+spark.sql(
+    f"COMMENT ON TABLE {WORKSPACE_IDENTITY_CHANGES_TABLE} IS "
+    "'SAT Permissions Analysis — workspace/identity changes from system.access.audit: identities created "
+    "or changed outside the AIM sync, and non-IdP identities assigned to workspaces. is_aim_sync marks the "
+    "automated sync vs a human actor; flagged marks findings that need review. Stamped with run_id.'"
+)
+for _col, _comment in {
+    "run_id":              "Detection run identifier in format YYYYMMDD_HHMMSS_hash",
+    "detection_timestamp": "UTC timestamp when this detection run executed",
+    "event_time":          "Timestamp of the change in the audit log",
+    "event_date":          "Date of the change in the audit log",
+    "action_name":         "Raw audit action_name",
+    "change_category":     "Normalized category (identity_created, group_membership_add, admin_grant, workspace_assignment_add, workspace_assignment_remove, account_workspace_access)",
+    "changed_via":         "workspace_admin (workspace UI/API) or account_admin (account console/API)",
+    "is_aim_sync":         "True if performed by the AIM sync process (request_params.endpoint = autoUserCreation); False = human actor",
+    "actor_email":         "Email of the identity that made the change",
+    "source_ip":           "Source IP of the change request",
+    "principal_id":        "SCIM id of the affected principal",
+    "principal_type":      "User, Group, ServicePrincipal, or Unknown (resolved from account SCIM)",
+    "principal_name":      "Display name of the affected principal",
+    "principal_email":     "Email / userName (users only)",
+    "application_id":      "OAuth application id (service principals only)",
+    "is_idp_managed":      "True if the affected principal carries an externalId (provisioned from an IdP)",
+    "related_group":       "For group-membership changes, the group the principal was added to",
+    "permission":          "Permission granted (USER/ADMIN, Workspace Access, account_admin), when applicable",
+    "workspace_id":        "Target workspace id (assignment events)",
+    "workspace_name":      "Workspace name from system.access.workspaces_latest",
+    "flagged":             "True if this change needs review (ungoverned identity change, or non-IdP workspace assignment)",
+    "flag_reason":         "Why the change was flagged, when flagged",
+    "console_url":         "Deep link to the account-console section for this principal type",
+    "auto_remediated":     "True if the workspace assignment was removed in this run",
+}.items():
+    spark.sql(f"ALTER TABLE {WORKSPACE_IDENTITY_CHANGES_TABLE} ALTER COLUMN `{_col}` COMMENT '{_comment.replace(chr(39), chr(39) * 2)}'")
+
+print(f"Wrote {findings_df.count()} finding(s) to {WORKSPACE_IDENTITY_CHANGES_TABLE} (run_id={RUN_ID})")
+
+# COMMAND ----------
+
+# DBTITLE 1,Display Findings
+if findings.empty:
+    print("✓ No workspace/identity changes detected in the selected window and scope.")
+else:
+    display(findings_df.orderBy(F.desc("flagged"), F.desc("event_time")))
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ---
+# MAGIC ## Understanding Results
+# MAGIC
+# MAGIC Each row is one audit event. **`flagged = true`** are the findings to review:
+# MAGIC
+# MAGIC - **`ungoverned_identity_creation` / `ungoverned_group_membership` / `ungoverned_admin_grant`** — a
+# MAGIC   human created/changed an identity, group membership, or admin role *outside* the AIM sync. These
+# MAGIC   should originate from your IdP.
+# MAGIC - **`workspace_assignment_of_non_idp_identity`** — a **non-IdP-managed** identity was assigned to a
+# MAGIC   workspace. Assigning identities to workspaces is fine; assigning a locally-created (non-governed)
+# MAGIC   one is the issue.
+# MAGIC
+# MAGIC Assignments of **IdP-managed** identities and **AIM-sync** events are recorded but not flagged — that
+# MAGIC is the expected, governed baseline.
+# MAGIC
+# MAGIC ### Recommended workflow
+# MAGIC
+# MAGIC 1. Run **report-only** (`remediate = no`) and review flagged rows.
+# MAGIC 2. Re-run with `remediate = yes` to remove flagged **non-IdP workspace assignments** (account-scoped;
+# MAGIC    removes workspace access only, leaves the account identity intact).
+# MAGIC 3. For flagged **identity creation / membership / admin** changes, remediate at the account level
+# MAGIC    manually (they are not auto-removed) and, ideally, re-provision the identity from your IdP.
+# MAGIC 4. Schedule this notebook (see `terraform/common/brickhound_workspace_identity_changes_job.tf`) to
+# MAGIC    keep detection fresh. Leave `remediate = no` in the job unless you intend continuous remediation.

--- a/notebooks/brickhound/08_workspace_identity_changes.py
+++ b/notebooks/brickhound/08_workspace_identity_changes.py
@@ -74,6 +74,7 @@
 # MAGIC | `last_n_days` | How far back to search the audit log (default 30). |
 # MAGIC | `finding_scope` | Comma-separated: `workspace_assignment`, `account_workspace_access`, `identity_creation`, `group_membership`, `admin_grant`. |
 # MAGIC | `remediate` | `yes` removes the workspace permission assignment for flagged non-IdP assignments. Default `no` (report-only). |
+# MAGIC | `disable_identities` | `yes` deactivates (SCIM `active=false`) flagged users / service principals added outside the AIM sync. **Destructive**; default `no`. |
 
 # COMMAND ----------
 
@@ -85,14 +86,17 @@ dbutils.widgets.text(
     "Finding scope (comma-separated)",
 )
 dbutils.widgets.dropdown("remediate", "no", ["no", "yes"], "Remove non-IdP workspace assignments")
+dbutils.widgets.dropdown("disable_identities", "no", ["no", "yes"], "Disable users/SPs added outside AIM")
 
-LAST_N_DAYS   = int(dbutils.widgets.get("last_n_days"))
-FINDING_SCOPE = [s.strip() for s in dbutils.widgets.get("finding_scope").split(",") if s.strip()]
-REMEDIATE     = dbutils.widgets.get("remediate") == "yes"
+LAST_N_DAYS        = int(dbutils.widgets.get("last_n_days"))
+FINDING_SCOPE      = [s.strip() for s in dbutils.widgets.get("finding_scope").split(",") if s.strip()]
+REMEDIATE          = dbutils.widgets.get("remediate") == "yes"
+DISABLE_IDENTITIES = dbutils.widgets.get("disable_identities") == "yes"
 
-print(f"Look-back window: {LAST_N_DAYS} days")
-print(f"Finding scope:    {FINDING_SCOPE}")
-print(f"Remediate:        {REMEDIATE}")
+print(f"Look-back window:   {LAST_N_DAYS} days")
+print(f"Finding scope:      {FINDING_SCOPE}")
+print(f"Remediate (assign): {REMEDIATE}")
+print(f"Disable identities: {DISABLE_IDENTITIES}")
 
 # COMMAND ----------
 
@@ -435,6 +439,7 @@ class WorkspaceIdentityChangeAuditor:
         flags = df.apply(flag, axis=1, result_type="expand")
         df["flagged"], df["flag_reason"] = flags[0].astype(bool), flags[1]
         df["auto_remediated"] = False
+        df["remediation_action"] = None
         return df
 
     # ── Remediation ────────────────────────────────────────────────────────────
@@ -492,6 +497,57 @@ class WorkspaceIdentityChangeAuditor:
             print(r)
         return results
 
+    def _disable_identity(self, principal_type: str, principal_id: str) -> tuple[str, str, bool, str]:
+        """Deactivate a user or service principal via account SCIM PATCH active=false.
+
+        Reversible (does not delete the identity); the principal simply can no
+        longer authenticate. Only Users / ServicePrincipals support `active` —
+        groups cannot be deactivated this way.
+        """
+        resource = {"User": "Users", "ServicePrincipal": "ServicePrincipals"}.get(principal_type)
+        if not resource:
+            return (principal_id, principal_type, False, "not a user/service principal")
+        url = f"{self._accounts_host}/api/2.0/accounts/{self._account_id}/scim/v2/{resource}/{principal_id}"
+        body = {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            "Operations": [{"op": "replace", "path": "active", "value": False}],
+        }
+        try:
+            resp = requests.patch(url, headers={**self._acct_hdrs, "Content-Type": "application/scim+json"},
+                                  json=body, proxies=self._proxies, timeout=30)
+        except requests.RequestException as e:
+            return (principal_id, principal_type, False, f"{type(e).__name__}")
+        return (principal_id, principal_type, resp.ok,
+                "deactivated" if resp.ok else f"PATCH {resp.status_code}: {resp.text[:150]}")
+
+    def disable_identities(self, df: pd.DataFrame, max_workers: int = 8) -> list[tuple]:
+        """Deactivate FLAGGED users/SPs added outside the AIM sync — either created
+        in the account (`identity_created`) or assigned to a workspace as a non-IdP
+        identity. Groups are excluded (SCIM `active` applies only to users/SPs).
+        """
+        targets = df[
+            df["flagged"]
+            & df["principal_type"].isin(["User", "ServicePrincipal"])
+            & df["change_category"].isin(
+                ["identity_created", "workspace_assignment_add", "account_workspace_access"])
+            & df["principal_id"].notna()
+        ].drop_duplicates("principal_id")
+
+        if targets.empty:
+            print("  No flagged users/service principals to disable.")
+            return []
+
+        results: list[tuple] = []
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = [pool.submit(self._disable_identity, row["principal_type"], str(row["principal_id"]))
+                       for _, row in targets.iterrows()]
+            for future in as_completed(futures):
+                results.append(future.result())
+
+        for pid, ptype, ok, msg in sorted(results, key=lambda r: (r[1], r[0])):
+            print(f"{'✓' if ok else '✗'} [{ptype}] {pid}: {msg}")
+        return results
+
 # COMMAND ----------
 
 # DBTITLE 1,Initialize Auditor & Build Identity Index
@@ -522,25 +578,42 @@ if not findings.empty:
 # COMMAND ----------
 
 # DBTITLE 1,Remediate (opt-in)
-if REMEDIATE and not findings.empty:
-    print("Remediating flagged non-IdP workspace assignments...\n")
-    results = auditor.remediate(findings)
-    ok = {(r.workspace_id, r.principal_id) for r in results if r.success}
-    findings["auto_remediated"] = findings.apply(
-        lambda x: (str(x["workspace_id"]), str(x["principal_id"])) in ok
-                  and x["change_category"] in ("workspace_assignment_add", "account_workspace_access")
-                  and bool(x["flagged"]),
-        axis=1,
-    )
-    other_flagged = int((findings["flagged"] & ~findings["change_category"].isin(
-        ["workspace_assignment_add", "account_workspace_access"])).sum())
-    if other_flagged:
-        print(f"\nℹ {other_flagged} flagged identity/membership/admin change(s) not auto-remediated "
-              "(review and remove the identity/role at the account level manually).")
-elif REMEDIATE:
-    print("Remediation enabled, but no findings to remediate.")
+ok_assign: set = set()   # (workspace_id, principal_id) whose assignment was removed
+ok_disable: set = set()  # principal_id that was deactivated
+
+if not findings.empty and (REMEDIATE or DISABLE_IDENTITIES):
+    if REMEDIATE:
+        print("Removing flagged non-IdP workspace assignments...\n")
+        results = auditor.remediate(findings)
+        ok_assign = {(r.workspace_id, r.principal_id) for r in results if r.success}
+    if DISABLE_IDENTITIES:
+        print("\nDisabling flagged users/service principals added outside AIM...\n")
+        disable_results = auditor.disable_identities(findings)
+        ok_disable = {pid for pid, ptype, success, msg in disable_results if success}
+
+    # Per-row remediation outcome. A principal can be both assignment-removed and
+    # disabled; record every action applied to that row.
+    def _action(row):
+        acts = []
+        if (row["change_category"] in ("workspace_assignment_add", "account_workspace_access")
+                and bool(row["flagged"])
+                and (str(row["workspace_id"]), str(row["principal_id"])) in ok_assign):
+            acts.append("assignment_removed")
+        if str(row["principal_id"]) in ok_disable:
+            acts.append("identity_disabled")
+        return ",".join(acts) if acts else None
+
+    findings["remediation_action"] = findings.apply(_action, axis=1)
+    findings["auto_remediated"] = findings["remediation_action"].notna()
+
+    manual = int((findings["flagged"] & findings["remediation_action"].isna()).sum())
+    if manual:
+        print(f"\nℹ {manual} flagged change(s) not auto-remediated (e.g. group creation, "
+              "membership, or admin grants — review/undo at the account level manually).")
+elif REMEDIATE or DISABLE_IDENTITIES:
+    print("Remediation enabled, but no findings to act on.")
 else:
-    print("Remediation not enabled — set the 'remediate' widget to 'yes' to take action.")
+    print("Remediation not enabled — set 'remediate' and/or 'disable_identities' to 'yes' to take action.")
 
 # COMMAND ----------
 
@@ -579,6 +652,7 @@ findings_schema = StructType([
     StructField("flag_reason",         StringType(),    True),
     StructField("console_url",         StringType(),    True),
     StructField("auto_remediated",     BooleanType(),   True),
+    StructField("remediation_action",  StringType(),    True),
 ])
 
 _cols = [
@@ -586,7 +660,7 @@ _cols = [
     "change_category", "changed_via", "is_aim_sync", "actor_email", "source_ip",
     "principal_id", "principal_type", "principal_name", "principal_email", "application_id",
     "is_idp_managed", "related_group", "permission", "workspace_id", "workspace_name",
-    "flagged", "flag_reason", "console_url", "auto_remediated",
+    "flagged", "flag_reason", "console_url", "auto_remediated", "remediation_action",
 ]
 
 if findings.empty:
@@ -637,7 +711,8 @@ for _col, _comment in {
     "flagged":             "True if this change needs review (ungoverned identity change, or non-IdP workspace assignment)",
     "flag_reason":         "Why the change was flagged, when flagged",
     "console_url":         "Deep link to the account-console section for this principal type",
-    "auto_remediated":     "True if the workspace assignment was removed in this run",
+    "auto_remediated":     "True if any remediation action was applied to this finding in this run",
+    "remediation_action":  "What was done: assignment_removed and/or identity_disabled (comma-separated), or null",
 }.items():
     spark.sql(f"ALTER TABLE {WORKSPACE_IDENTITY_CHANGES_TABLE} ALTER COLUMN `{_col}` COMMENT '{_comment.replace(chr(39), chr(39) * 2)}'")
 
@@ -671,10 +746,12 @@ else:
 # MAGIC
 # MAGIC ### Recommended workflow
 # MAGIC
-# MAGIC 1. Run **report-only** (`remediate = no`) and review flagged rows.
+# MAGIC 1. Run **report-only** (`remediate = no`, `disable_identities = no`) and review flagged rows.
 # MAGIC 2. Re-run with `remediate = yes` to remove flagged **non-IdP workspace assignments** (account-scoped;
 # MAGIC    removes workspace access only, leaves the account identity intact).
-# MAGIC 3. For flagged **identity creation / membership / admin** changes, remediate at the account level
-# MAGIC    manually (they are not auto-removed) and, ideally, re-provision the identity from your IdP.
-# MAGIC 4. Schedule this notebook (see `terraform/common/brickhound_workspace_identity_changes_job.tf`) to
-# MAGIC    keep detection fresh. Leave `remediate = no` in the job unless you intend continuous remediation.
+# MAGIC 3. Optionally set `disable_identities = yes` to **deactivate** (SCIM `active=false`) flagged users /
+# MAGIC    service principals added outside the AIM sync — reversible, and leaves the identity in place for
+# MAGIC    audit. Groups are not deactivated (SCIM `active` doesn't apply); undo those at the account level.
+# MAGIC 4. Both actions are recorded per row in `remediation_action` (`assignment_removed` / `identity_disabled`).
+# MAGIC 5. Schedule this notebook (see `terraform/common/brickhound_workspace_identity_changes_job.tf`) to
+# MAGIC    keep detection fresh. Leave both actions `no` in the job unless you intend continuous remediation.

--- a/notebooks/brickhound/08_workspace_identity_changes.py
+++ b/notebooks/brickhound/08_workspace_identity_changes.py
@@ -41,6 +41,10 @@
 # MAGIC the expected, governed baseline. What SAT proves is *that an ungoverned-looking change happened, and
 # MAGIC who/when* — it cannot by itself prove whether an Entra entitlement-management approval backed it.
 # MAGIC
+# MAGIC **Platform-managed Databricks App service principals are excluded.** Deploying a Databricks App
+# MAGIC auto-creates an SP (audit `endpoint = DatabricksApps`); these are not ungoverned human onboarding, so
+# MAGIC they are dropped from detection entirely and are never flagged or disabled.
+# MAGIC
 # MAGIC ### Scope of the two admin paths
 # MAGIC
 # MAGIC - **Workspace admins** assigning identities via the workspace UI → `updatePermissionAssignment`
@@ -372,6 +376,11 @@ class WorkspaceIdentityChangeAuditor:
             FROM system.access.audit
             WHERE action_name = '{action}' AND service_name = '{service}'
               {extra}
+              -- Exclude platform-managed Databricks App service principals: deploying
+              -- an app auto-creates an SP via the DatabricksApps endpoint. These are
+              -- not ungoverned human onboarding, so they must never be flagged or
+              -- disabled (disabling one would take down a live app).
+              AND coalesce(request_params['endpoint'], '') <> 'DatabricksApps'
               AND event_time >= '{since}'
         """
 

--- a/notebooks/brickhound/08_workspace_identity_changes.py
+++ b/notebooks/brickhound/08_workspace_identity_changes.py
@@ -400,6 +400,18 @@ class WorkspaceIdentityChangeAuditor:
         if df.empty:
             return df
 
+        # Drop events with a blank principal_id. Creating a service principal or
+        # group emits a secondary audit event whose id lands in a different field
+        # (a second scim `add` with empty targetUserId, or a createGroup with
+        # endpoint=permissionAssignment carrying the id in targetUserId), leaving
+        # our extracted principal_id empty. These are duplicates of the real
+        # creation event (which has the id and resolves) — dropping them removes
+        # spurious "Unknown" rows without losing any genuine finding.
+        df = df[df["principal_id"].map(
+            lambda v: v is not None and str(v).strip() not in ("", "None"))].copy()
+        if df.empty:
+            return df
+
         def enrich(row):
             info = index.get(str(row["principal_id"])) if row.get("principal_id") else None
             if info:

--- a/notebooks/brickhound/08_workspace_identity_changes.py
+++ b/notebooks/brickhound/08_workspace_identity_changes.py
@@ -1,6 +1,6 @@
 # Databricks notebook source
 # MAGIC %md
-# MAGIC # Workspace & Identity Changes — Detection & Remediation
+# MAGIC # Workspace Identity Changes — Detection & Remediation
 # MAGIC *Catch identities introduced outside your IdP, and non-IdP identities assigned to workspaces*
 # MAGIC
 # MAGIC <div style="background-color: #fff3e0; border-left: 4px solid #d32f2f; padding: 12px; margin: 16px 0;">
@@ -288,10 +288,14 @@ class WorkspaceIdentityChangeAuditor:
                 }
         return index
 
-    def _console_url(self, principal_type: Optional[str]) -> str:
+    def _console_url(self, principal_type: Optional[str], principal_id: Optional[str]) -> str:
+        """Deep link to the account-console detail page for a principal (mirrors 06/07)."""
         segment = {"Group": "groups", "User": "users",
                    "ServicePrincipal": "serviceprincipals"}.get(principal_type or "", "users")
-        return f"{self._accounts_host}/user-management/{segment}"
+        if not principal_id:
+            return f"{self._accounts_host}/user-management/{segment}"
+        return (f"{self._accounts_host}/user-management/{segment}/{principal_id}"
+                f"?account_id={self._account_id}")
 
     # ── Detection ──────────────────────────────────────────────────────────────
 
@@ -408,7 +412,7 @@ class WorkspaceIdentityChangeAuditor:
                 "principal_email": pemail,
                 "application_id":  app_id,
                 "is_idp_managed":  idp,
-                "console_url":     self._console_url(ptype),
+                "console_url":     self._console_url(ptype, row.get("principal_id")),
             })
 
         df = df.copy()

--- a/notebooks/brickhound/README.md
+++ b/notebooks/brickhound/README.md
@@ -50,7 +50,8 @@ Use the interactive analysis notebooks:
 >   heuristic). Feeds the "Account Denylist Builder" tab.
 > - `08_workspace_identity_changes.py` → `brickhound_workspace_identity_changes`. Flags
 >   identities created/changed by a human outside the AIM sync (via the `autoUserCreation`
->   tag), and non-IdP identities assigned to workspaces. Two opt-in remediations, both default
+>   tag), and non-IdP identities assigned to workspaces. Platform-managed Databricks App SPs
+>   (`endpoint=DatabricksApps`) are excluded. Two opt-in remediations, both default
 >   off: `remediate=yes` removes flagged non-IdP workspace assignments (account-scoped), and
 >   `disable_identities=yes` deactivates flagged users / service principals via account SCIM
 >   `active=false` (reversible; groups excluded). The `remediation_action` column records what

--- a/notebooks/brickhound/README.md
+++ b/notebooks/brickhound/README.md
@@ -31,8 +31,9 @@ Use the interactive analysis notebooks:
 | `05_share_to_account.py` | Detect (and optionally remediate) resources shared with all account users |
 | `06_privileged_non_idp_identities.py` | Detect (and optionally remediate) privileged identities that are not IdP-managed |
 | `07_denylist_candidates.py` | Rank account groups by inactive members as account-denylist candidates |
+| `08_workspace_identity_changes.py` | Detect (and optionally remediate) identities changed outside the AIM sync, and non-IdP identities assigned to workspaces |
 
-> **Note:** `05`–`07` are **audit-log / account-SCIM based**, not graph based. They read
+> **Note:** `05`–`08` are **audit-log / account-SCIM based**, not graph based. They read
 > `system.access.audit`, `system.access.workspaces_latest`, and the account SCIM API
 > directly, so they do **not** require the data collection job to have run first. Each writes
 > its own `brickhound_*` table and has a scheduled job (in both `terraform/common/` and the
@@ -47,6 +48,10 @@ Use the interactive analysis notebooks:
 > - `07_denylist_candidates.py` → `brickhound_denylist_candidates`. Ranks account groups by
 >   inactive-member count (inactive = no `system.access.audit` activity in the window — a
 >   heuristic). Feeds the "Account Denylist Builder" tab.
+> - `08_workspace_identity_changes.py` → `brickhound_workspace_identity_changes`. Flags
+>   identities created/changed by a human outside the AIM sync (via the `autoUserCreation`
+>   tag), and non-IdP identities assigned to workspaces. Opt-in remediation removes flagged
+>   non-IdP workspace assignments (account-scoped). Feeds the "Workspace Identity Changes" tab.
 
 ### 3. Web UI (Optional)
 

--- a/notebooks/brickhound/README.md
+++ b/notebooks/brickhound/README.md
@@ -50,8 +50,11 @@ Use the interactive analysis notebooks:
 >   heuristic). Feeds the "Account Denylist Builder" tab.
 > - `08_workspace_identity_changes.py` → `brickhound_workspace_identity_changes`. Flags
 >   identities created/changed by a human outside the AIM sync (via the `autoUserCreation`
->   tag), and non-IdP identities assigned to workspaces. Opt-in remediation removes flagged
->   non-IdP workspace assignments (account-scoped). Feeds the "Workspace Identity Changes" tab.
+>   tag), and non-IdP identities assigned to workspaces. Two opt-in remediations, both default
+>   off: `remediate=yes` removes flagged non-IdP workspace assignments (account-scoped), and
+>   `disable_identities=yes` deactivates flagged users / service principals via account SCIM
+>   `active=false` (reversible; groups excluded). The `remediation_action` column records what
+>   was done. Feeds the "Workspace Identity Changes" tab (per-run selector + remediated filter).
 
 ### 3. Web UI (Optional)
 
@@ -65,7 +68,7 @@ https://<workspace-url>/apps/brickhound-sat
 BrickHound automatically uses SAT's configuration:
 - **Credentials**: From `sat_scope` secret scope
 - **Schema**: From SAT's `analysis_schema_name`
-- **Tables**: `brickhound_vertices`, `brickhound_edges`, `brickhound_collection_metadata`, `brickhound_shared_to_account`
+- **Tables**: `brickhound_vertices`, `brickhound_edges`, `brickhound_collection_metadata`, `brickhound_shared_to_account`, `brickhound_privileged_non_idp`, `brickhound_denylist_candidates`, `brickhound_workspace_identity_changes`
 
 No additional configuration needed if SAT is installed!
 

--- a/terraform/common/brickhound_workspace_identity_changes_job.tf
+++ b/terraform/common/brickhound_workspace_identity_changes_job.tf
@@ -60,9 +60,10 @@ resource "databricks_job" "brickhound_workspace_identity_changes" {
       # Detection-only by default. Set remediate=yes deliberately to enable
       # continuous removal of non-IdP workspace assignments.
       base_parameters = {
-        last_n_days   = "30"
-        finding_scope = "workspace_assignment,account_workspace_access,identity_creation,group_membership,admin_grant"
-        remediate     = "no"
+        last_n_days        = "30"
+        finding_scope      = "workspace_assignment,account_workspace_access,identity_creation,group_membership,admin_grant"
+        remediate          = "no"
+        disable_identities = "no"
       }
     }
 

--- a/terraform/common/brickhound_workspace_identity_changes_job.tf
+++ b/terraform/common/brickhound_workspace_identity_changes_job.tf
@@ -1,10 +1,10 @@
-# SAT Permissions Analysis - Workspace & Identity Changes Detection Job
+# SAT Permissions Analysis - Workspace Identity Changes Detection Job
 # Detects (and optionally remediates) identities created/changed outside the AIM
 # sync, and non-IdP identities assigned to workspaces. Writes findings to
 # brickhound_workspace_identity_changes.
 
 resource "databricks_job" "brickhound_workspace_identity_changes" {
-  name = "SAT Permissions Analysis - Workspace & Identity Changes (Experimental)"
+  name = "SAT Permissions Analysis - Workspace Identity Changes (Experimental)"
 
   tags = {
     Application = "SAT"
@@ -77,6 +77,6 @@ resource "databricks_job" "brickhound_workspace_identity_changes" {
 }
 
 output "brickhound_workspace_identity_changes_job_id" {
-  description = "The ID of the SAT workspace & identity changes detection job"
+  description = "The ID of the SAT workspace identity changes detection job"
   value       = databricks_job.brickhound_workspace_identity_changes.id
 }

--- a/terraform/common/brickhound_workspace_identity_changes_job.tf
+++ b/terraform/common/brickhound_workspace_identity_changes_job.tf
@@ -1,0 +1,82 @@
+# SAT Permissions Analysis - Workspace & Identity Changes Detection Job
+# Detects (and optionally remediates) identities created/changed outside the AIM
+# sync, and non-IdP identities assigned to workspaces. Writes findings to
+# brickhound_workspace_identity_changes.
+
+resource "databricks_job" "brickhound_workspace_identity_changes" {
+  name = "SAT Permissions Analysis - Workspace & Identity Changes (Experimental)"
+
+  tags = {
+    Application = "SAT"
+  }
+
+  dynamic "job_cluster" {
+    for_each = var.run_on_serverless ? [] : [1]
+    content {
+      job_cluster_key = "brickhound_workspace_identity_changes_cluster"
+      new_cluster {
+        data_security_mode = "SINGLE_USER"
+        num_workers        = 3
+        spark_version      = data.databricks_spark_version.latest_lts.id
+        node_type_id       = data.databricks_node_type.smallest.id
+        runtime_engine     = "PHOTON"
+
+        dynamic "aws_attributes" {
+          for_each = var.cloud_type == "aws" ? [1] : []
+          content {
+            availability    = "SPOT_WITH_FALLBACK"
+            first_on_demand = 1
+          }
+        }
+
+        dynamic "gcp_attributes" {
+          for_each = var.gcp_impersonate_service_account == "" ? [] : [var.gcp_impersonate_service_account]
+          content {
+            google_service_account = var.gcp_impersonate_service_account
+          }
+        }
+      }
+    }
+  }
+
+  dynamic "environment" {
+    for_each = var.run_on_serverless ? [1] : []
+    content {
+      environment_key = "default"
+      spec {
+        client = "5"
+      }
+    }
+  }
+
+  task {
+    task_key        = "BrickHoundWorkspaceIdentityChanges"
+    job_cluster_key = var.run_on_serverless ? null : "brickhound_workspace_identity_changes_cluster"
+    environment_key = var.run_on_serverless ? "default" : null
+
+    notebook_task {
+      notebook_path = "${databricks_repo.security_analysis_tool.path}/notebooks/brickhound/08_workspace_identity_changes"
+
+      # Detection-only by default. Set remediate=yes deliberately to enable
+      # continuous removal of non-IdP workspace assignments.
+      base_parameters = {
+        last_n_days   = "30"
+        finding_scope = "workspace_assignment,account_workspace_access,identity_creation,group_membership,admin_grant"
+        remediate     = "no"
+      }
+    }
+
+    timeout_seconds = 3600 # 1 hour
+  }
+
+  # Schedule: weekly (Sunday 6 AM ET), staggered after the other SAT jobs
+  schedule {
+    quartz_cron_expression = "0 0 6 ? * SUN"
+    timezone_id            = "America/New_York"
+  }
+}
+
+output "brickhound_workspace_identity_changes_job_id" {
+  description = "The ID of the SAT workspace & identity changes detection job"
+  value       = databricks_job.brickhound_workspace_identity_changes.id
+}


### PR DESCRIPTION
## Summary
Adds a new BrickHound / Permissions Analysis detection+remediation surface, plus a robustness fix to the existing report tabs (bundled as a separate documented commit).

### New feature — Workspace & Identity Changes (`08`)
Motivated by an AIM governance concern: a workspace admin can pull Entra identities into a workspace, and identities can be created outside the IdP sync. New `notebooks/brickhound/08_workspace_identity_changes.py` reads `system.access.audit` and flags, distinguishing human actions from the AIM sync via the `request_params.endpoint = 'autoUserCreation'` tag:
- **Ungoverned identity changes** — human (not AIM sync) `add` / `createGroup` / `addPrincipalToGroup(s)` / `setAdmin`.
- **Non-IdP workspace assignments** — `updatePermissionAssignment` (workspace admin) / `changeDatabricksWorkspaceAcl` (account admin) where the assigned principal has no `externalId`. Assigning IdP-managed identities is the governed baseline — recorded, not flagged.

Each principal is enriched from account SCIM (type / name / IdP-managed). Opt-in remediation removes flagged non-IdP workspace assignments via the account-scoped `permissionassignments` DELETE (workspace access only; account identity untouched), reusing notebook 06's cross-workspace-safe pattern. Findings land in `brickhound_workspace_identity_changes` (run_id snapshots) and render in a new read-only **Workspace Identity Changes** app tab. Weekly job (Sun 6 AM) added to `terraform/common` and the DABS template, `remediate=no` by default.

All audit `action_name`s and `request_params` keys were verified against a live `system.access.audit` table before writing the queries.

### Bundled fix (commit `4913d9d`) — report robustness
- `exec_query_df` now follows result chunks (no silent truncation of multi-chunk results).
- The three existing report queries are bounded (`LIMIT REPORT_ROW_CAP + 1`) with a truncation banner, so a large account can't overflow the ~25 MB inline result and show a false "no findings".
- Report endpoints re-raise `NoAccessError` so a missing UC grant shows the access banner.
- Notebook `07` excludes zero-member IdP groups by default (opt-in `include_zero_member_groups`) — they are AIM false positives.

## Testing (live, on an AWS workspace)
- Notebook 08 ran green; detected 6 ungoverned identity changes (5 human-created SPs + 1 group-membership add), correct flag reasons and SCIM enrichment (incl. the `Unknown` fallback for a since-deleted principal).
- 05/06/07 re-run green; `07` now returns 0 zero-member false positives.
- App redeployed; new tab renders. All report tabs use the bounded-query / truncation / NoAccessError handling.

This pull request and its description were written by Isaac.
