### PR TITLE
fix: run cleanup cells even when a scan fails

### DIFF
--- a/notebooks/Includes/scan_secrets/cluster_secrets_scan.py
+++ b/notebooks/Includes/scan_secrets/cluster_secrets_scan.py
@@ -904,40 +904,48 @@ def main_cluster_scanning_workflow():
 # COMMAND ----------
 
 # Execute the main workflow
-results = main_cluster_scanning_workflow()
+results = None
+scan_error = None
+try:
+    results = main_cluster_scanning_workflow()
+except Exception as e:
+    scan_error = e
 
 # COMMAND ----------
 
 # Display final summary and recommendations
-print("\n🎯 Cluster Secret Scanning - Final Summary")
-print("=" * 60)
-print(f"📊 Total clusters found: {results['total_clusters']}")
-print(f"🔍 Clusters scanned: {results['clusters_scanned']}")
-print(f"🚨 Clusters with secrets: {results['clusters_with_secrets']}")
-print(f"🔑 Total secrets detected: {results['total_secrets_found']}")
-print(f"🆔 Run ID: {results['run_id']}")
+if results:
+    print("\n🎯 Cluster Secret Scanning - Final Summary")
+    print("=" * 60)
+    print(f"📊 Total clusters found: {results['total_clusters']}")
+    print(f"🔍 Clusters scanned: {results['clusters_scanned']}")
+    print(f"🚨 Clusters with secrets: {results['clusters_with_secrets']}")
+    print(f"🔑 Total secrets detected: {results['total_secrets_found']}")
+    print(f"🆔 Run ID: {results['run_id']}")
 
-print("\n🎯 Next Steps and Recommendations")
-print("=" * 60)
+    print("\n🎯 Next Steps and Recommendations")
+    print("=" * 60)
 
-if results['clusters_with_secrets'] > 0:
-    print("⚠️  IMMEDIATE ACTION REQUIRED:")
-    print("   Secrets were detected in cluster configurations!")
-    print("\n📋 Recommended Actions:")
-    print("1. 🔍 Review the clusters_secret_scan_results table in the SAT dashboard")
-    print("2. 🔄 Rotate any exposed credentials immediately")
-    print("3. 📝 Update cluster configurations to remove hardcoded secrets")
-    print("4. 🔐 Use Databricks secrets scope instead of spark_env_vars")
-    print("5. 📅 Schedule regular cluster configuration scans")
-    print("6. 📋 Implement policy to prevent secrets in cluster configs")
+    if results['clusters_with_secrets'] > 0:
+        print("⚠️  IMMEDIATE ACTION REQUIRED:")
+        print("   Secrets were detected in cluster configurations!")
+        print("\n📋 Recommended Actions:")
+        print("1. 🔍 Review the clusters_secret_scan_results table in the SAT dashboard")
+        print("2. 🔄 Rotate any exposed credentials immediately")
+        print("3. 📝 Update cluster configurations to remove hardcoded secrets")
+        print("4. 🔐 Use Databricks secrets scope instead of spark_env_vars")
+        print("5. 📅 Schedule regular cluster configuration scans")
+        print("6. 📋 Implement policy to prevent secrets in cluster configs")
+    else:
+        print("✅ No immediate action required - no secrets detected in cluster configurations.")
+        print("\n📋 Best Practices:")
+        print("1. 🔐 Continue using Databricks secrets for sensitive values")
+        print("2. 📅 Schedule regular scans as part of security workflow")
+        print("3. 🎓 Educate team on secure configuration practices")
+
+    print("\n✅ Cluster Secret Scanning Completed Successfully!")
 else:
-    print("✅ No immediate action required - no secrets detected in cluster configurations.")
-    print("\n📋 Best Practices:")
-    print("1. 🔐 Continue using Databricks secrets for sensitive values")
-    print("2. 📅 Schedule regular scans as part of security workflow")
-    print("3. 🎓 Educate team on secure configuration practices")
-
-print("\n✅ Cluster Secret Scanning Completed Successfully!")
+    print(f"\n❌ Cluster Secret Scanning failed: {scan_error}")
 
 # COMMAND ----------
 
@@ -976,3 +984,8 @@ print("   - TruffleHog binary is shared with notebook scanning (/tmp/trufflehog)
 
 # Note: We don't use dbutils.notebook.exit() here to preserve the output above
 # The orchestrator doesn't need the return value - it just checks for completion
+
+# COMMAND ----------
+
+if scan_error is not None:
+    raise scan_error

--- a/notebooks/Includes/scan_secrets/notebook_secret_scan.py
+++ b/notebooks/Includes/scan_secrets/notebook_secret_scan.py
@@ -1494,8 +1494,13 @@ def main_scanning_workflow():
         raise
 
 # Execute the scanning workflow
+scan_results = None
+scan_error = None
 if __name__ == "__main__":
-    scan_results = main_scanning_workflow()
+    try:
+        scan_results = main_scanning_workflow()
+    except Exception as e:
+        scan_error = e
 
 # COMMAND ----------
 
@@ -1599,6 +1604,11 @@ if 'scan_results' in locals() and scan_results and scan_results.get("notebooks_w
     print("   Secrets were detected in your notebooks. Please address them promptly!")
 else:
     print("\n✅ No immediate action required - no secrets detected.")
+
+# COMMAND ----------
+
+if 'scan_error' in locals() and scan_error is not None:
+    raise scan_error
 
 # COMMAND ----------
 


### PR DESCRIPTION
## Summary
- Databricks notebooks execute cells sequentially and halt entirely on an uncaught exception, so when `main_scanning_workflow()` / `main_cluster_scanning_workflow()` raised, every subsequent cell — including cleanup and results-analysis cells — was silently skipped.
- Capture the exception into `scan_error` instead of letting it propagate immediately, allow the notebook to run through cleanup/summary cells (guarding the ones that dereference a now-possibly-`None` result), then re-raise `scan_error` in a final cell so `dbutils.notebook.run()` still correctly reports the failure to the calling orchestrator.
- Applied to both `notebook_secret_scan.py` and `cluster_secrets_scan.py`.

Fixes #392

## Test plan
- [ ] `python3 -m py_compile` on both changed files
- [ ] Force a scan failure (e.g. malformed workspace config) and confirm cleanup/summary cells still print, and the notebook still ultimately raises so the orchestrator sees the failure.