### PR TITLE
feat: add Terraform toggle to install TruffleHog via cluster init script

### DIFF
--- a/scripts/init/install_trufflehog.sh
+++ b/scripts/init/install_trufflehog.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Databricks cluster init script: installs TruffleHog once at cluster startup.
+#
+# Used when var.install_trufflehog_via_init_script is set to true in the SAT
+# Terraform (terraform/common/jobs.tf, databricks_job.secrets_scanner). This
+# avoids the secrets-scanner notebooks racing on /tmp/trufflehog when multiple
+# concurrent scans land on the same cluster.
+#
+# NOTE: TRUFFLEHOG_VERSION here must be kept in sync with the copies hardcoded
+# in notebooks/Includes/scan_secrets/notebook_secret_scan.py and
+# notebooks/Includes/scan_secrets/cluster_secrets_scan.py.
+
+set -euo pipefail
+
+if [ -f /tmp/trufflehog ]; then
+    echo "TruffleHog already installed at /tmp/trufflehog"
+    exit 0
+fi
+
+# Pinned to a tagged release to prevent supply-chain tampering via the
+# mutable main branch. Bump TRUFFLEHOG_VERSION to upgrade.
+TRUFFLEHOG_VERSION=v3.94.3
+echo "Installing TruffleHog ${TRUFFLEHOG_VERSION}..."
+
+if curl -sSfL "https://raw.githubusercontent.com/trufflesecurity/trufflehog/refs/tags/${TRUFFLEHOG_VERSION}/scripts/install.sh" | sh -s -- -b /tmp "${TRUFFLEHOG_VERSION}"; then
+    if [ -f /tmp/trufflehog ]; then
+        echo "TruffleHog installed successfully at /tmp/trufflehog"
+    else
+        echo "ERROR: TruffleHog binary not found after installation!"
+        exit 1
+    fi
+else
+    echo "=========================================="
+    echo "ERROR: Failed to download TruffleHog"
+    echo "=========================================="
+    echo ""
+    echo "The TruffleHog security scanner could not be downloaded from:"
+    echo "https://raw.githubusercontent.com/trufflesecurity/trufflehog/refs/tags/${TRUFFLEHOG_VERSION}/scripts/install.sh"
+    echo ""
+    echo "Possible causes:"
+    echo "  1. Network connectivity issues"
+    echo "  2. Firewall or proxy blocking external downloads"
+    echo "  3. GitHub.com access is restricted in your environment"
+    echo ""
+    echo "ACTION REQUIRED:"
+    echo "Please contact your IT/Security team to allowlist access to:"
+    echo "  - raw.githubusercontent.com"
+    echo "  - github.com/trufflesecurity"
+    exit 1
+fi

--- a/terraform/common/jobs.tf
+++ b/terraform/common/jobs.tf
@@ -158,6 +158,14 @@ resource "databricks_job" "secrets_scanner" {
             google_service_account = var.gcp_impersonate_service_account
           }
         }
+        dynamic "init_scripts" {
+          for_each = var.install_trufflehog_via_init_script ? [1] : []
+          content {
+            workspace {
+              destination = "${databricks_repo.security_analysis_tool.path}/scripts/init/install_trufflehog.sh"
+            }
+          }
+        }
       }
     }
   }

--- a/terraform/common/variables.tf
+++ b/terraform/common/variables.tf
@@ -106,6 +106,12 @@ variable "sql_warehouse_enable_serverless" {
   default     = false
 }
 
+variable "install_trufflehog_via_init_script" {
+  type        = bool
+  description = "Install TruffleHog via a cluster init script at startup instead of per-notebook-run, avoiding install races when secret scans run concurrently on the same cluster."
+  default     = false
+}
+
 variable "sql_warehouse_auto_stop_mins" {
   type        = number
   description = "Time in minutes until an idle SQL warehouse terminates all clusters and stops. This field is optional. The default is 120, set to 0 to disable the auto stop."


### PR DESCRIPTION
## Summary
- Add `install_trufflehog_via_init_script` Terraform variable (default `false`, backwards compatible) to `terraform/common/variables.tf`.
- When enabled, attaches `scripts/init/install_trufflehog.sh` as a cluster init script on the `secrets_scanner` job's cluster (`terraform/common/jobs.tf`), installing TruffleHog once at cluster startup instead of racing on `/tmp/trufflehog` across concurrent notebook/cluster secret scans landing on the same cluster.
- No notebook changes needed — the existing `if [ -f /tmp/trufflehog ]` idempotency check in the per-notebook `%sh` install cells already no-ops once the init script has placed the binary.
- Scoped to the `secrets_scanner` job only, since it's the only job that installs TruffleHog. No-ops correctly when `run_on_serverless = true` (init scripts aren't supported on serverless, so the whole `new_cluster` block — and this new one — simply isn't rendered).

Fixes #396

## Test plan
- [x] `terraform validate` passes in `terraform/common`
- [ ] `terraform plan`/`apply` with `install_trufflehog_via_init_script = true` against a real workspace to confirm the init script attaches and installs successfully at cluster startup
- [ ] Confirm default (`false`) produces no diff for existing deployments